### PR TITLE
close on ^D without errors

### DIFF
--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -14,7 +14,7 @@ namespace Neo.Services
 
         protected bool ShowPrompt { get; set; } = true;
 
-		protected virtual bool OnCommand(string[] args)
+        protected virtual bool OnCommand(string[] args)
         {
             switch (args[0].ToLower())
             {
@@ -130,12 +130,10 @@ namespace Neo.Services
                 }
 
                 Console.ForegroundColor = ConsoleColor.Yellow;
-                string line = Console.ReadLine();
-                if (line == null)
-                    break;
-
+                string line = Console.ReadLine()?.Trim();
+                if (line == null) break;
                 Console.ForegroundColor = ConsoleColor.White;
-                string[] args = line.Trim().Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] args = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                 if (args.Length == 0)
                     continue;
                 try


### PR DESCRIPTION
Hello!

I usually use Ctrl+D to exit from all REPLs, however neo-cli exits with error:
```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Neo.Services.ConsoleServiceBase.RunConsole()
   at Neo.Services.ConsoleServiceBase.Run(String[] args)
   at Neo.Program.Main(String[] args)
[1]    14067 abort (core dumped)  dotnet neo-cli/bin/Release/netcoreapp2.0/neo-cli.dll /rpc
```
neo-python, for example, handles this correctly.

This small PR fixes it.