### PR TITLE
Showing version of neo and neo-vm on startup

### DIFF
--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -352,7 +352,7 @@ namespace Neo.Services
 
             Console.ForegroundColor = ConsoleColor.DarkGreen;
 
-            var cliV = Assembly.GetEntryAssembly().GetVersion();
+            var cliV = Assembly.GetAssembly(typeof(Program)).GetVersion();
             var neoV = Assembly.GetAssembly(typeof(NeoSystem)).GetVersion();
             var vmV = Assembly.GetAssembly(typeof(ExecutionEngine)).GetVersion();
             Console.WriteLine($"{ServiceName} v{cliV}  -  NEO v{neoV}  -  NEO-VM v{vmV}");

--- a/neo-cli/Services/ConsoleServiceBase.cs
+++ b/neo-cli/Services/ConsoleServiceBase.cs
@@ -1,3 +1,4 @@
+using Neo.VM;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -350,7 +351,11 @@ namespace Neo.Services
                 catch { }
 
             Console.ForegroundColor = ConsoleColor.DarkGreen;
-            Console.WriteLine($"{ServiceName} Version: {Assembly.GetEntryAssembly().GetVersion()}");
+
+            var cliV = Assembly.GetEntryAssembly().GetVersion();
+            var neoV = Assembly.GetAssembly(typeof(NeoSystem)).GetVersion();
+            var vmV = Assembly.GetAssembly(typeof(ExecutionEngine)).GetVersion();
+            Console.WriteLine($"{ServiceName} v{cliV}  -  NEO v{neoV}  -  NEO-VM v{vmV}");
             Console.WriteLine();
 
             while (_running)


### PR DESCRIPTION
![screenshot](https://i.imgur.com/mkGC8Sl.png)

@igormcoelho opened this issue https://github.com/neo-project/neo/issues/668 about printing neo versions on the log and @vncoelho suggested to print the git commit hash aswell.

I made a NerdBank.GitVersioning setup on the project to use a `version.json` file to define the version code (as suggested by @devhawk) and the git commit hash and save on AssemblyInformation.

This setup was made on neo and neo-vm aswell, if this PR is approved I can send PR for them so all versions will be printed with the commit hash.

I don't know if this solution satisfy all the needs presented by Igor, let me know if there is anything else I could do.