### PR TITLE
Fixed GAS decimals

### DIFF
--- a/neo-cli/CLI/MainService.cs
+++ b/neo-cli/CLI/MainService.cs
@@ -311,7 +311,7 @@ namespace Neo.CLI
             using (ApplicationEngine engine = ApplicationEngine.Run(tx.Script, tx, testMode: true))
             {
                 Console.WriteLine($"VM State: {engine.State}");
-                Console.WriteLine($"Gas Consumed: {engine.GasConsumed}");
+                Console.WriteLine($"Gas Consumed: {new BigDecimal(engine.GasConsumed, NativeContract.GAS.Decimals)}");
                 Console.WriteLine($"Evaluation Stack: {new JArray(engine.ResultStack.Select(p => p.ToParameter().ToJson()))}");
                 Console.WriteLine();
                 if (engine.State.HasFlag(VMState.FAULT))


### PR DESCRIPTION
Another bug, similar to this one https://github.com/neo-project/neo-node/pull/547

before
![image](https://user-images.githubusercontent.com/6295602/76292557-67b4e880-62ea-11ea-9f0f-30cddc1b8080.png)

after
![image](https://user-images.githubusercontent.com/6295602/76292564-6aafd900-62ea-11ea-9399-06d6720fedb9.png)
