### PR TITLE
Remove `StackItem.ToParameter()`

### DIFF
--- a/neo-cli/CLI/MainService.cs
+++ b/neo-cli/CLI/MainService.cs
@@ -495,7 +495,7 @@ namespace Neo.CLI
                 {
                     Console.WriteLine($"VM State: {engine.State}");
                     Console.WriteLine($"Gas Consumed: {new BigDecimal(engine.GasConsumed, NativeContract.GAS.Decimals)}");
-                    Console.WriteLine($"Evaluation Stack: {new JArray(engine.ResultStack.Select(p => p.ToParameter().ToJson()))}");
+                    Console.WriteLine($"Evaluation Stack: {new JArray(engine.ResultStack.Select(p => p.ToJson()))}");
                     Console.WriteLine();
                     if (engine.State.HasFlag(VMState.FAULT))
                     {


### PR DESCRIPTION
Change `StackItem.ToParameter().ToJson()`  to `StackItem.ToJson()` when parsing `engine.ResultStack`.