### PR TITLE
Add description and uninstall restriction for "SystemLog"

### DIFF
--- a/neo-cli/CLI/Logger.cs
+++ b/neo-cli/CLI/Logger.cs
@@ -16,6 +16,7 @@ namespace Neo.CLI
         private static readonly ConsoleColorSet FatalColor = new ConsoleColorSet(ConsoleColor.Red);
 
         public override string Name => "SystemLog";
+        public override string Description => "Prints consensus log and is a built-in plugin which cannot be uninstalled";
         public override string ConfigFile => Combine(GetDirectoryName(Path), "config.json");
         public override string Path => GetType().Assembly.Location;
 

--- a/neo-cli/CLI/MainService.Plugins.cs
+++ b/neo-cli/CLI/MainService.Plugins.cs
@@ -104,7 +104,11 @@ namespace Neo.CLI
             if (Plugin.Plugins.Count > 0)
             {
                 Console.WriteLine("Loaded plugins:");
-                Plugin.Plugins.ForEach(p => { if (p.Name != "SystemLog") Console.WriteLine("\t" + p.Name + "\t" + p.Description); });
+                foreach (Plugin plugin in Plugin.Plugins)
+                {
+                    if (plugin is Logger) continue;
+                    Console.WriteLine("\t" + plugin.Name + "\t" + plugin.Description);
+                }
             }
             else
             {

--- a/neo-cli/CLI/MainService.Plugins.cs
+++ b/neo-cli/CLI/MainService.Plugins.cs
@@ -71,15 +71,15 @@ namespace Neo.CLI
         [ConsoleCommand("uninstall", Category = "Plugin Commands")]
         private void OnUnInstallCommand(string pluginName)
         {
-            if (pluginName == "SystemLog")
-            {
-                Console.WriteLine("You cannot uninstall a built-in plugin.");
-                return;
-            }
             var plugin = Plugin.Plugins.FirstOrDefault(p => p.Name == pluginName);
             if (plugin is null)
             {
                 Console.WriteLine("Plugin not found");
+                return;
+            }
+            if (plugin is Logger)
+            {
+                Console.WriteLine("You cannot uninstall a built-in plugin.");
                 return;
             }
 

--- a/neo-cli/CLI/MainService.Plugins.cs
+++ b/neo-cli/CLI/MainService.Plugins.cs
@@ -71,6 +71,11 @@ namespace Neo.CLI
         [ConsoleCommand("uninstall", Category = "Plugin Commands")]
         private void OnUnInstallCommand(string pluginName)
         {
+            if (pluginName == "SystemLog")
+            {
+                Console.WriteLine("You cannot uninstall a built-in plugin.");
+                return;
+            }
             var plugin = Plugin.Plugins.FirstOrDefault(p => p.Name == pluginName);
             if (plugin is null)
             {

--- a/neo-cli/CLI/MainService.Plugins.cs
+++ b/neo-cli/CLI/MainService.Plugins.cs
@@ -104,7 +104,7 @@ namespace Neo.CLI
             if (Plugin.Plugins.Count > 0)
             {
                 Console.WriteLine("Loaded plugins:");
-                Plugin.Plugins.ForEach(p => Console.WriteLine("\t" + p.Name + "\t" + p.Description));
+                Plugin.Plugins.ForEach(p => { if (p.Name != "SystemLog") Console.WriteLine("\t" + p.Name + "\t" + p.Description); });
             }
             else
             {


### PR DESCRIPTION
Close #601 

This may look stupid.🤣 Maybe we should not implement "SystemLog" as a plugin, but which needs modification from neo-core: 

```c#
        public static void Log(string source, LogLevel level, object message)
        {
            foreach (ILogPlugin plugin in Plugin.Loggers)
                plugin.Log(source, level, message);
        }
```