### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.0 AS Build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS Build
 
 COPY neo-cli /neo-cli
 COPY Neo.ConsoleService /Neo.ConsoleService
@@ -7,7 +7,7 @@ COPY NuGet.Config /neo-cli
 WORKDIR /neo-cli
 RUN dotnet restore && dotnet publish -c Release -o /app
 
-FROM mcr.microsoft.com/dotnet/runtime:5.0.0 AS Final
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS Final
 RUN apt-get update && apt-get install -y \
   screen \
   libleveldb-dev \


### PR DESCRIPTION
We need to pay more attention when the `Dockerfile` is modified. It's the second time I fix changes that are made in this file, which seems that is modified without any tests. Maybe I can add some `Dockerfile` tests in the future.

In the PR I  solved the following:

```
Step 1/12 : FROM mcr.microsoft.com/dotnet/sdk:5.0.0 AS Build
ERROR: Service 'build-neo-cli' failed to build: manifest for mcr.microsoft.com/dotnet/sdk:5.0.0 not found: manifest unknown: manifest tagged by "5.0.0" is not found
```

As stated [here](https://hub.docker.com/_/microsoft-dotnet-sdk/), the best way to tag is `5.0` or specific ones, like `5.0.102`.

Also, I solved something else:

When we use `mcr.microsoft.com/dotnet/runtime:5.0` to run the `neo-cli.dll`, the following message appeared:

```
root@eb171729224b:/neo-cli# dotnet neo-cli.dll -r
It was not possible to find any compatible framework version
The framework 'Microsoft.AspNetCore.App', version '5.0.0' was not found.
  - No frameworks were found.

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=5.0.0&arch=x64&rid=debian.10-x64
root@eb171729224b:/neo-cli#
```

That's why I changed and switched to `mcr.microsoft.com/dotnet/aspnet:5.0`.
