### PR TITLE
Update Magic Number

### DIFF
--- a/neo-cli/config.json
+++ b/neo-cli/config.json
@@ -21,7 +21,7 @@
     "PluginURL": "https://github.com/neo-project/neo-modules/releases/download/v{1}/{0}.zip"
   },
   "ProtocolConfiguration": {
-    "Network": 5195086,
+    "Network": 827601742,
     "MillisecondsPerBlock": 15000,
     "MaxTraceableBlocks": 2102400,
     "ValidatorsCount": 7,

--- a/neo-cli/config.testnet.json
+++ b/neo-cli/config.testnet.json
@@ -21,7 +21,7 @@
     "PluginURL": "https://github.com/neo-project/neo-modules/releases/download/v{1}/{0}.zip"
   },
   "ProtocolConfiguration": {
-    "Network": 1951352142,
+    "Network": 827601742,
     "MillisecondsPerBlock": 15000,
     "MaxTraceableBlocks": 2102400,
     "ValidatorsCount": 7,


### PR DESCRIPTION
The testnet is currently using a different magic number from the configuration file resulting in unnecessary difficulty for users when trying to build on the network.