### PR TITLE
neo-cli: tune MaxTransactionsPerBlock for testnet

### DIFF
--- a/neo-cli/config.testnet.json
+++ b/neo-cli/config.testnet.json
@@ -26,7 +26,7 @@
     "Network": 877933390,
     "AddressVersion": 53,
     "MillisecondsPerBlock": 15000,
-    "MaxTransactionsPerBlock": 512,
+    "MaxTransactionsPerBlock": 5000,
     "MemoryPoolMaxTransactions": 50000,
     "MaxTraceableBlocks": 2102400,
     "InitialGasDistribution": 5200000000000000,


### PR DESCRIPTION
Allow to flush the mempool in just 10 blocks.