### PR TITLE
Add new testnet network id

### DIFF
--- a/neo-cli/config.testnet.json
+++ b/neo-cli/config.testnet.json
@@ -23,7 +23,7 @@
     }
   },
   "ProtocolConfiguration": {
-    "Network": 877933390,
+    "Network": 894710606,
     "AddressVersion": 53,
     "MillisecondsPerBlock": 15000,
     "MaxTransactionsPerBlock": 5000,


### PR DESCRIPTION
Since testnet data is incompatible now becasue of the modification of native contract, we could create a new testnet `N3T5`. Wait for a better solution on native contract update.