### PR TITLE
Update Dockerfile to use dotnet 7.0

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,22 @@
+name: Docker Build Test
+
+on: pull_request
+
+jobs:
+  docker-build-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Build-Test
+      run: |
+        docker buildx build \
+          --no-cache \
+          --tag ghcr.io/neo-project/neo-node:latest \
+          --platform linux/amd64,linux/arm64 \
+          ./neo-node

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -19,4 +19,4 @@ jobs:
           --no-cache \
           --tag ghcr.io/neo-project/neo-node:latest \
           --platform linux/amd64,linux/arm64 \
-          ./neo-node
+          ./

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - name: Build-Test
       run: |
         docker buildx build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS Build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS Build
 
 COPY neo-cli /neo-cli
 COPY Neo.ConsoleService /Neo.ConsoleService
@@ -7,7 +7,7 @@ COPY NuGet.Config /neo-cli
 WORKDIR /neo-cli
 RUN dotnet restore && dotnet publish -c Release -o /app
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS Final
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS Final
 RUN apt-get update && apt-get install -y \
   screen \
   libleveldb-dev \


### PR DESCRIPTION
As mentioned [here](https://github.com/neo-project/neo/commit/ee93a8dd9a4b4fad4eb1a9a2e11ae6e06bffaf8e), I believe that **once again** the `Dockerfile` was simply ignored after the upgrade from dotnet 6 to 7.

It already happened more than once: developers change code but they simply forget to update other parts of the repo that do not fail on the build time. There are some Neo projects relying on this `Dockerfile`, especially for tests.

This PR makes the whole GitHub Action workflow fail if anything is merged and something with `Dockerfile` image is not right (e.g., wrong dotnet version, or anything like that).

The next step would be to enhance to check if the Docker image at least starts with the node.. but that's a bit more work and I haven't included it in this PR. One thing at a time. 😄 