### PR TITLE
set the testnet hardfork height to 0

### DIFF
--- a/neo-cli/config.testnet.json
+++ b/neo-cli/config.testnet.json
@@ -30,7 +30,7 @@
     "MemoryPoolMaxTransactions": 50000,
     "MaxTraceableBlocks": 2102400,
     "Hardforks": {
-      "HF_Aspidochelone": 210000
+      "HF_Aspidochelone": 0
     },
     "InitialGasDistribution": 5200000000000000,
     "ValidatorsCount": 7,


### PR DESCRIPTION
Possible solution to https://github.com/neo-project/neo/pull/2886

If we set up a new testnet or a private net, all hardforks are enabled by default since the genesis. 