### PR TITLE
Update Dockerfile to properly enable multi platform

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,6 +1,8 @@
 name: Docker Build Test
 
-on: pull_request
+on: 
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   docker-build-test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS Build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS Build
 
 COPY neo-cli /neo-cli
 COPY Neo.ConsoleService /Neo.ConsoleService
@@ -7,7 +7,7 @@ COPY NuGet.Config /neo-cli
 WORKDIR /neo-cli
 RUN dotnet restore && dotnet publish -c Release -o /app
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS Final
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0 AS Final
 RUN apt-get update && apt-get install -y \
   screen \
   libleveldb-dev \


### PR DESCRIPTION
As described [here](https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/), we followed the proper way to use dotnet docker images with `buildx` (multi-platform).