### PR TITLE
add cancel command for conflict attribute

### DIFF
--- a/neo-cli/CLI/MainService.Wallet.cs
+++ b/neo-cli/CLI/MainService.Wallet.cs
@@ -603,7 +603,6 @@ namespace Neo.CLI
                 Witnesses = Array.Empty<Witness>(),
             };
 
-            if (NoWallet()) return;
             try
             {
                 using (ScriptBuilder scriptBuilder= new())

--- a/neo-cli/CLI/MainService.Wallet.cs
+++ b/neo-cli/CLI/MainService.Wallet.cs
@@ -605,9 +605,8 @@ namespace Neo.CLI
             try
             {
                 using ScriptBuilder scriptBuilder = new();
-                scriptBuilder.Emit(OpCode.NOP);
+                scriptBuilder.Emit(OpCode.RET);
                 tx = CurrentWallet.MakeTransaction(NeoSystem.StoreView, scriptBuilder.ToArray(), sender, signers, conflict);
-
             }
             catch (InvalidOperationException e)
             {
@@ -630,7 +629,6 @@ namespace Neo.CLI
                     return;
                 }
                 tx.NetworkFee += (long)decimalExtraFee.Value;
-
             };
 
             ConsoleHelper.Info("Network fee: ",

--- a/neo-cli/CLI/MainService.Wallet.cs
+++ b/neo-cli/CLI/MainService.Wallet.cs
@@ -24,7 +24,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
-using System.Security.Policy;
 using System.Threading.Tasks;
 using static Neo.SmartContract.Helper;
 
@@ -605,12 +604,10 @@ namespace Neo.CLI
 
             try
             {
-                using (ScriptBuilder scriptBuilder= new())
-                {
-                    scriptBuilder.Emit(OpCode.NOP);
-                    tx = CurrentWallet.MakeTransaction(NeoSystem.StoreView, scriptBuilder.ToArray(), sender, signers, conflict);
-                }
-                    
+                using ScriptBuilder scriptBuilder = new();
+                scriptBuilder.Emit(OpCode.NOP);
+                tx = CurrentWallet.MakeTransaction(NeoSystem.StoreView, scriptBuilder.ToArray(), sender, signers, conflict);
+
             }
             catch (InvalidOperationException e)
             {
@@ -618,9 +615,11 @@ namespace Neo.CLI
                 return;
             }
 
-            if (NeoSystem.MemPool.TryGetValue(txid, out Transaction conflictTx)){
-                tx.NetworkFee = Math.Max(tx.NetworkFee, conflictTx.NetworkFee)+1;
-            } else
+            if (NeoSystem.MemPool.TryGetValue(txid, out Transaction conflictTx))
+            {
+                tx.NetworkFee = Math.Max(tx.NetworkFee, conflictTx.NetworkFee) + 1;
+            }
+            else
             {
                 var snapshot = NeoSystem.StoreView;
                 AssetDescriptor descriptor = new(snapshot, NeoSystem.Settings, NativeContract.GAS.Hash);

--- a/neo-cli/CLI/MainService.Wallet.cs
+++ b/neo-cli/CLI/MainService.Wallet.cs
@@ -562,16 +562,13 @@ namespace Neo.CLI
         }
 
         /// <summary>
-        /// Process "invoke" command
+        /// Process "cancel" command
         /// </summary>
-        /// <param name="scriptHash">Script hash</param>
-        /// <param name="operation">Operation</param>
-        /// <param name="contractParameters">Contract parameters</param>
+        /// <param name="txid">conflict txid</param>
         /// <param name="sender">Transaction's sender</param>
         /// <param name="signerAccounts">Signer's accounts</param>
-        /// <param name="maxGas">Max fee for running the script</param>
         [ConsoleCommand("cancel", Category = "Wallet Commands")]
-        private void OnCancelCommand(UInt256 txid, UInt160 sender = null, UInt160[] signerAccounts = null, decimal maxGas = 20)
+        private void OnCancelCommand(UInt256 txid, UInt160 sender = null, UInt160[] signerAccounts = null)
         {
             TransactionState state = NativeContract.Ledger.GetTransactionState(NeoSystem.StoreView, txid);
             if (state != null)
@@ -581,7 +578,6 @@ namespace Neo.CLI
             }
 
             var conflict = new TransactionAttribute[] { new Conflicts() { Hash = txid } };
-            var gas = new BigDecimal(maxGas, NativeContract.GAS.Decimals);
             Signer[] signers = Array.Empty<Signer>();
             if (!NoWallet() && sender != null)
             {
@@ -613,7 +609,7 @@ namespace Neo.CLI
                 using (ScriptBuilder scriptBuilder= new())
                 {
                     scriptBuilder.Emit(OpCode.NOP);
-                    tx = CurrentWallet.MakeTransaction(NeoSystem.StoreView, scriptBuilder.ToArray(), sender, signers, conflict, maxGas: (long)gas.Value);
+                    tx = CurrentWallet.MakeTransaction(NeoSystem.StoreView, scriptBuilder.ToArray(), sender, signers, conflict);
                 }
                     
             }


### PR DESCRIPTION
Related to: https://github.com/neo-project/neo/pull/2818
1. Add `cancel` command.
2. Check if aimed tx is in mempool, if it is, choose the max networkfee between the current and the aimed. If it isn't, wait for inputting networkfee manually.
3. Add a `NOP` to tx.script to ensure not rejected by consensus.
4. Return error when aimed tx is already confirmed.