### PR TITLE
fix unit test according 4.0

### DIFF
--- a/tests/Neo.Network.RPC.Tests/RpcTestCases.json
+++ b/tests/Neo.Network.RPC.Tests/RpcTestCases.json
@@ -3155,12 +3155,7 @@
           "maxtransactionsperblock": 0,
           "memorypoolmaxtransactions": 0,
           "initialgasdistribution": 0,
-          "hardforks": [
-            {
-              "name": "Aspidochelone",
-              "blockheight": 0
-            }
-          ],
+          "hardforks": [],
           "standbycommittee": [
             "03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c",
             "02df48f60e8f3e01c48ff40b9b7f1310d7a8b2a193188befe1c2e3df740e895093",

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
@@ -717,7 +717,8 @@ partial class UT_RpcServer
             validatorSigner.AsParameter<SignersAndWitnesses>()
         );
         Assert.AreEqual(nameof(VMState.FAULT), resp["state"]);
-        Assert.AreEqual("Object reference not set to an instance of an object.", resp["exception"]);
+        Assert.IsNotNull(resp["exception"]);
+        Assert.Contains("hashOrPubkey", resp["exception"].AsString());
 
         // invoke verify with 1 param and signer; should return true
         resp = (JObject)_rpcServer.InvokeContractVerify(


### PR DESCRIPTION
- Remove hardfork from RpcTestCases.json after removing hardforks in version 4
- Adapt TestInvokeContractVerify expected value from "Object reference..." to "The argument ... can't be null."