### PR TITLE
[master] fix readonly issue in Deserialize

### DIFF
--- a/plugins/TokensTracker/Trackers/NEP-11/Nep11BalanceKey.cs
+++ b/plugins/TokensTracker/Trackers/NEP-11/Nep11BalanceKey.cs
@@ -17,8 +17,8 @@ namespace Neo.Plugins.Trackers.NEP_11;
 
 public class Nep11BalanceKey : IComparable<Nep11BalanceKey>, IEquatable<Nep11BalanceKey>, ISerializable
 {
-    public readonly UInt160 UserScriptHash;
-    public readonly UInt160 AssetScriptHash;
+    public UInt160 UserScriptHash { get; private set; }
+    public UInt160 AssetScriptHash { get; private set; }
     public ByteString Token;
     public int Size => UInt160.Length + UInt160.Length + Token.GetVarSize();
 
@@ -74,8 +74,8 @@ public class Nep11BalanceKey : IComparable<Nep11BalanceKey>, IEquatable<Nep11Bal
 
     public void Deserialize(ref MemoryReader reader)
     {
-        ((ISerializable)UserScriptHash).Deserialize(ref reader);
-        ((ISerializable)AssetScriptHash).Deserialize(ref reader);
+        UserScriptHash = reader.ReadSerializable<UInt160>();
+        AssetScriptHash = reader.ReadSerializable<UInt160>();
         Token = reader.ReadVarMemory();
     }
 }

--- a/plugins/TokensTracker/Trackers/NEP-17/Nep17BalanceKey.cs
+++ b/plugins/TokensTracker/Trackers/NEP-17/Nep17BalanceKey.cs
@@ -16,8 +16,8 @@ namespace Neo.Plugins.Trackers.NEP_17;
 
 public class Nep17BalanceKey : IComparable<Nep17BalanceKey>, IEquatable<Nep17BalanceKey>, ISerializable
 {
-    public readonly UInt160 UserScriptHash;
-    public readonly UInt160 AssetScriptHash;
+    public UInt160 UserScriptHash { get; private set; }
+    public UInt160 AssetScriptHash { get; private set; }
 
     public int Size => UInt160.Length + UInt160.Length;
 
@@ -66,7 +66,7 @@ public class Nep17BalanceKey : IComparable<Nep17BalanceKey>, IEquatable<Nep17Bal
 
     public void Deserialize(ref MemoryReader reader)
     {
-        ((ISerializable)UserScriptHash).Deserialize(ref reader);
-        ((ISerializable)AssetScriptHash).Deserialize(ref reader);
+        UserScriptHash = reader.ReadSerializable<UInt160>();
+        AssetScriptHash = reader.ReadSerializable<UInt160>();
     }
 }


### PR DESCRIPTION
Fix https://github.com/neo-project/neo-node/issues/928, readonly `UserScriptHash` and `AssetScriptHash` isn't able to be `Deserialize()`