### PR TITLE
[N3] Unify RPC logic and fix size check

### DIFF
--- a/plugins/RpcServer/RpcServer.Wallet.cs
+++ b/plugins/RpcServer/RpcServer.Wallet.cs
@@ -371,13 +371,7 @@ partial class RpcServer
         if (!transContext.Completed) return transContext.ToJson();
 
         tx.Witnesses = transContext.GetWitnesses();
-        if (tx.Size > 1024)
-        {
-            long calFee = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot) + 100000;
-            if (tx.NetworkFee < calFee)
-                tx.NetworkFee = calFee;
-        }
-        (tx.NetworkFee <= settings.MaxFee).True_Or(RpcError.WalletFeeLimit);
+        EnsureNetworkFee(snapshot, tx);
         return SignAndRelay(snapshot, tx);
     }
 
@@ -488,13 +482,7 @@ partial class RpcServer
         if (!transContext.Completed) return transContext.ToJson();
 
         tx.Witnesses = transContext.GetWitnesses();
-        if (tx.Size > 1024)
-        {
-            long calFee = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot) + 100000;
-            if (tx.NetworkFee < calFee)
-                tx.NetworkFee = calFee;
-        }
-        (tx.NetworkFee <= settings.MaxFee).True_Or(RpcError.WalletFeeLimit);
+        EnsureNetworkFee(snapshot, tx);
         return SignAndRelay(snapshot, tx);
     }
 
@@ -551,14 +539,16 @@ partial class RpcServer
             return transContext.ToJson();
 
         tx.Witnesses = transContext.GetWitnesses();
-        if (tx.Size > 1024)
-        {
-            long calFee = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot) + 100000;
-            if (tx.NetworkFee < calFee)
-                tx.NetworkFee = calFee;
-        }
-        (tx.NetworkFee <= settings.MaxFee).True_Or(RpcError.WalletFeeLimit);
+        EnsureNetworkFee(snapshot, tx);
         return SignAndRelay(snapshot, tx);
+    }
+
+    private void EnsureNetworkFee(StoreCache snapshot, Transaction tx)
+    {
+        long calFee = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot) + 100000;
+        if (tx.NetworkFee < calFee)
+            tx.NetworkFee = calFee;
+        (tx.NetworkFee <= settings.MaxFee).True_Or(RpcError.WalletFeeLimit);
     }
 
     /// <summary>


### PR DESCRIPTION
The condition tx.Length > 1024 has been removed because it is not present in the transaction validation.

This pull request refactors network fee calculation logic in the `RpcServer.Wallet.cs` file to improve code maintainability and reduce duplication. The main change is the extraction of repeated fee calculation code into a new helper method, which is then used in multiple transaction-related methods.

Refactoring for maintainability:

* Introduced a new private method `EnsureNetworkFee` to encapsulate the network fee calculation and limit enforcement logic, replacing duplicated code in transaction creation methods (`SendFrom`, `SendMany`, and `SendToAddress`).
* Updated `SendFrom`, `SendMany`, and `SendToAddress` methods to use the new `EnsureNetworkFee` helper, removing inline fee calculation logic and simplifying these methods. [[1]](diffhunk://#diff-117ada1714c3ef54ab7a33751d40147a8bcb45c8f47ad9a664eb15a277c7c353L374-R374) [[2]](diffhunk://#diff-117ada1714c3ef54ab7a33751d40147a8bcb45c8f47ad9a664eb15a277c7c353L491-R485) [[3]](diffhunk://#diff-117ada1714c3ef54ab7a33751d40147a8bcb45c8f47ad9a664eb15a277c7c353L554-L561)