### PR TITLE
StorageDumper plugin optimization

### DIFF
--- a/plugins/StorageDumper/StorageDumper.cs
+++ b/plugins/StorageDumper/StorageDumper.cs
@@ -124,7 +124,7 @@ public class StorageDumper : Plugin
 
             _currentBlock = new JObject()
             {
-                ["block"] = blockIndex,
+                ["block"] = block.Index,
                 ["size"] = stateChangeArray.Count,
                 ["storage"] = stateChangeArray
             };


### PR DESCRIPTION
To carefully verify the difference between states 3.8 and 3.9, we need to add the gas consumption and transaction states.

Those are the main changes:

- Avoid query `NativeContract.Ledger.CurrentIndex(snapshot)` when we can use the `Block` argument.
- Added `applicationExecutedList` because also it's important to check the differences.