### PR TITLE
Fix mempool

### DIFF
--- a/plugins/DBFTPlugin/Consensus/ConsensusService.cs
+++ b/plugins/DBFTPlugin/Consensus/ConsensusService.cs
@@ -73,7 +73,7 @@ internal partial class ConsensusService : UntypedActor
 
     private void MemPool_NewTransaction(object sender, NewTransactionEventArgs e)
     {
-        e.Cancel = e.Transaction.SystemFee <= dbftSettings.MaxBlockSystemFee;
+        e.Cancel = e.Transaction.SystemFee >= dbftSettings.MaxBlockSystemFee;
     }
 
     private void OnPersistCompleted(Block block)


### PR DESCRIPTION
This pull request makes a small but important logic correction in the `ConsensusService` class. The change updates the condition for canceling new transactions based on their system fee.

* The transaction cancellation logic in the `MemPool_NewTransaction` method was updated: transactions are now canceled if their `SystemFee` is greater than or equal to `dbftSettings.MaxBlockSystemFee`, instead of less than or equal to.