### PR TITLE
Auto Release Part I: CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
             cp -r "$build_output"/* "./out/Plugins/$plugin_name/"
           fi
         done
+        # Remove duplicated RpcServer.dll from TokensTracker and StorageDumper (they can't load twice)
         rm -f ./out/Plugins/TokensTracker/RpcServer.dll
         rm -f ./out/Plugins/StateService/RpcServer.dll
     - name: Install dependencies


### PR DESCRIPTION
Since neo-node is using immutable release now. It's necessary to make auto-release workflow because we can only release once and  it can never be changed. This is the first part of neo-node auto-release workflow (only for CLI now, I will add plugins in Part II). It automatically build & pack CLI & upload to release draft.  Most OS can run it without installing any additional dependency. For mac users, they may need `brew install gperftools`, no more others. I've tried this on my own repo and it works well.

How to test this:
1. Fork it to your own repo, checkout `master-n3`.
2. Replace `neo-project` with your own `user name`.
3. For quick test, you can comment out `Publish to NuGet` part.
4. Change `neo-node\src\Directory.Build.props`, make `<VersionPrefix>3.9.3</VersionPrefix>` as `<Version>3.9.3</Version>`.