### PR TITLE
Neo.CLI: set MaxTransactionsPerBlock to 200 for N3 mainnet

### DIFF
--- a/src/Neo.CLI/config.json
+++ b/src/Neo.CLI/config.json
@@ -33,7 +33,7 @@
     "Network": 860833102,
     "AddressVersion": 53,
     "MillisecondsPerBlock": 15000,
-    "MaxTransactionsPerBlock": 512,
+    "MaxTransactionsPerBlock": 200,
     "MemoryPoolMaxTransactions": 50000,
     "MaxTraceableBlocks": 2102400,
     "Hardforks": {

--- a/src/Neo.CLI/config.mainnet.json
+++ b/src/Neo.CLI/config.mainnet.json
@@ -33,7 +33,7 @@
     "Network": 860833102,
     "AddressVersion": 53,
     "MillisecondsPerBlock": 15000,
-    "MaxTransactionsPerBlock": 512,
+    "MaxTransactionsPerBlock": 200,
     "MemoryPoolMaxTransactions": 50000,
     "MaxTraceableBlocks": 2102400,
     "Hardforks": {


### PR DESCRIPTION
Ref. https://neonewstoday.com/governance/neo-council-approves-3-second-block-time-defers-fee-reduction-to-gorgon-hard-fork/. The default value will not be changed.