### PR TITLE
[N4] - Update github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:
@@ -39,7 +39,7 @@ jobs:
         dotnet test /p:CollectCoverage=true /p:CoverletOutput='${{ github.workspace }}/TestResults/coverage/' /p:MergeWith='${{ github.workspace }}/TestResults/coverage/coverage.json' /p:CoverletOutputFormat=lcov%2cjson -m:1
     - name: Codecov
       if: runner.os == 'Windows'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/TestResults/coverage/coverage.info


### PR DESCRIPTION
## Summary

Updates GitHub Actions

## Changes

- Updated `actions/checkout` from `v5` to `v6`.
- Updated `codecov/codecov-action` from `v5` to `v6`.
