### PR TITLE
Fix RPC gas limit defaults

### DIFF
--- a/plugins/RpcServer/RcpServerSettings.cs
+++ b/plugins/RpcServer/RcpServerSettings.cs
@@ -88,8 +88,8 @@ public record RpcServersSettings
             AllowOrigins = GetStrings(section, "AllowOrigins"),
             KeepAliveTimeout = section.GetValue(nameof(KeepAliveTimeout), @default.KeepAliveTimeout),
             RequestHeadersTimeout = section.GetValue(nameof(RequestHeadersTimeout), @default.RequestHeadersTimeout),
-            MaxGasInvoke = (long)new BigDecimal(section.GetValue<decimal>("MaxGasInvoke", @default.MaxGasInvoke), NativeContract.GAS.Decimals).Value,
-            MaxFee = (long)new BigDecimal(section.GetValue<decimal>("MaxFee", @default.MaxFee), NativeContract.GAS.Decimals).Value,
+            MaxGasInvoke = GetGasAmount(section, "MaxGasInvoke", @default.MaxGasInvoke),
+            MaxFee = GetGasAmount(section, "MaxFee", @default.MaxFee),
             MaxIteratorResultItems = section.GetValue("MaxIteratorResultItems", @default.MaxIteratorResultItems),
             MaxStackSize = section.GetValue("MaxStackSize", @default.MaxStackSize),
             DisabledMethods = GetStrings(section, "DisabledMethods"),
@@ -99,6 +99,12 @@ public record RpcServersSettings
             SessionExpirationTime = TimeSpan.FromSeconds(section.GetValue("SessionExpirationTime", (long)@default.SessionExpirationTime.TotalSeconds)),
             FindStoragePageSize = section.GetValue("FindStoragePageSize", @default.FindStoragePageSize)
         };
+    }
+
+    private static long GetGasAmount(IConfigurationSection section, string key, long defaultValue)
+    {
+        if (!section.GetSection(key).Exists()) return defaultValue;
+        return (long)new BigDecimal(section.GetValue<decimal>(key), NativeContract.GAS.Decimals).Value;
     }
 
     private static string[] GetStrings(IConfigurationSection section, string key)

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.cs
@@ -432,4 +432,27 @@ public partial class UT_RpcServer
         Assert.AreEqual(5 * 1024 * 1024, settings.MaxRequestBodySize);
         Assert.AreEqual(50, settings.FindStoragePageSize);
     }
+
+    [TestMethod]
+    public void TestRpcServerSettings_LoadMissingGasLimitsUsesDefaultDatoshiValues()
+    {
+        const string json = """
+        {
+          "Server": {
+            "Network": 860833102,
+            "BindAddress": "127.0.0.1",
+            "Port": 10332
+          }
+        }
+        """;
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            .Build()
+            .GetSection("Server");
+
+        var settings = RpcServersSettings.Load(config);
+
+        Assert.AreEqual(RpcServersSettings.Default.MaxGasInvoke, settings.MaxGasInvoke);
+        Assert.AreEqual(RpcServersSettings.Default.MaxFee, settings.MaxFee);
+    }
 }

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.cs
@@ -434,6 +434,19 @@ public partial class UT_RpcServer
     }
 
     [TestMethod]
+    public void TestRpcServerSettings_LoadPluginConfiguration()
+    {
+        var settings = new RpcServerSettings(new ConfigurationBuilder()
+            .AddJsonFile("RpcServer.json")
+            .Build()
+            .GetSection("PluginConfiguration"));
+
+        Assert.AreEqual(UnhandledExceptionPolicy.Ignore, settings.ExceptionPolicy);
+        Assert.HasCount(1, settings.Servers);
+        Assert.AreEqual(860833102u, settings.Servers[0].Network);
+    }
+
+    [TestMethod]
     public void TestRpcServerSettings_LoadMissingGasLimitsUsesDefaultDatoshiValues()
     {
         const string json = """

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_Tree.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_Tree.cs
@@ -1,0 +1,46 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_Tree.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+namespace Neo.Plugins.RpcServer.Tests;
+
+[TestClass]
+public class UT_Tree
+{
+    [TestMethod]
+    public void TestGetItemsReturnsDepthFirstItems()
+    {
+        Tree<string> tree = new();
+
+        Assert.IsNull(tree.Root);
+        Assert.IsEmpty(tree.GetItems());
+
+        var root = tree.AddRoot("root");
+        var left = root.AddChild("left");
+        left.AddChild("left.child");
+        root.AddChild("right");
+
+        Assert.AreSame(root, tree.Root);
+        Assert.AreEqual("root", root.Item);
+        Assert.IsNull(root.Parent);
+        Assert.AreSame(root, left.Parent);
+        Assert.HasCount(2, root.Children);
+        CollectionAssert.AreEqual(new[] { "root", "left", "left.child", "right" }, tree.GetItems().ToArray());
+    }
+
+    [TestMethod]
+    public void TestAddRootRejectsSecondRoot()
+    {
+        Tree<int> tree = new();
+        tree.AddRoot(1);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => tree.AddRoot(2));
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve default `MaxGasInvoke` and `MaxFee` values when they are omitted from an RPC server config.
- Continue converting explicitly configured GAS decimal values to datoshi.
- Add regression coverage for partial RPC server configuration.

## Testing
- `dotnet test tests/Neo.Plugins.RpcServer.Tests/Neo.Plugins.RpcServer.Tests.csproj -c Release --no-restore`
