### PR TITLE
Fix OracleService start-after-stop state

### DIFF
--- a/plugins/OracleService/OracleService.cs
+++ b/plugins/OracleService/OracleService.cs
@@ -46,17 +46,17 @@ public sealed class OracleService : Plugin
 
     private Wallet wallet;
     private readonly ConcurrentDictionary<ulong, OracleTask> pendingQueue = new();
-    private readonly ConcurrentDictionary<ulong, DateTime> finishedCache = new();
+    internal readonly ConcurrentDictionary<ulong, DateTime> finishedCache = new();
     private Timer timer;
     internal CancellationTokenSource cancelSource = new();
-    private OracleStatus status = OracleStatus.Unstarted;
-    private Task processingTask;
-    private readonly object lifecycleLock = new();
+    internal OracleStatus status = OracleStatus.Unstarted;
+    internal Task processingTask;
+    private readonly Lock lifecycleLock = new();
     private IWalletProvider walletProvider;
     private int counter;
-    private NeoSystem _system;
+    internal NeoSystem _system;
 
-    private readonly Dictionary<string, IOracleProtocol> protocols = new();
+    internal readonly Dictionary<string, IOracleProtocol> protocols = new();
 
     public override string Description => "Built-in oracle plugin";
 
@@ -178,7 +178,7 @@ public sealed class OracleService : Plugin
     }
 
     [ConsoleCommand("stop oracle", Category = "Oracle", Description = "Stop oracle service")]
-    private void OnStop()
+    internal void OnStop()
     {
         lock (lifecycleLock)
         {
@@ -585,7 +585,7 @@ public sealed class OracleService : Plugin
         }
     }
 
-    private void MarkRequestFinished(ulong requestId)
+    internal void MarkRequestFinished(ulong requestId)
     {
         finishedCache.TryAdd(requestId, TimeProvider.Current.UtcNow);
     }
@@ -652,7 +652,7 @@ public sealed class OracleService : Plugin
         public readonly DateTime Timestamp = TimeProvider.Current.UtcNow;
     }
 
-    enum OracleStatus
+    internal enum OracleStatus
     {
         Unstarted,
         Running,

--- a/plugins/OracleService/OracleService.cs
+++ b/plugins/OracleService/OracleService.cs
@@ -111,8 +111,7 @@ public sealed class OracleService : Plugin
         OnStop();
         while (status != OracleStatus.Stopped)
             Thread.Sleep(100);
-        foreach (var p in protocols)
-            p.Value.Dispose();
+        DisposeProtocols();
         base.Dispose();
     }
 
@@ -125,7 +124,7 @@ public sealed class OracleService : Plugin
     public Task Start(Wallet wallet)
     {
         if (status == OracleStatus.Running) return Task.CompletedTask;
-        ResetCancellationSource();
+        DisposeProtocols();
 
         if (wallet is null)
         {
@@ -145,6 +144,7 @@ public sealed class OracleService : Plugin
             return Task.CompletedTask;
         }
 
+        ResetCancellationSource();
         this.wallet = wallet;
         protocols["https"] = new OracleHttpsProtocol();
         protocols["neofs"] = new OracleNeoFSProtocol(wallet, oracles);
@@ -158,6 +158,13 @@ public sealed class OracleService : Plugin
     {
         if (cancelSource.IsCancellationRequested)
             cancelSource = new CancellationTokenSource();
+    }
+
+    private void DisposeProtocols()
+    {
+        foreach (var protocol in protocols.Values)
+            protocol.Dispose();
+        protocols.Clear();
     }
 
     [ConsoleCommand("stop oracle", Category = "Oracle", Description = "Stop oracle service")]

--- a/plugins/OracleService/OracleService.cs
+++ b/plugins/OracleService/OracleService.cs
@@ -50,6 +50,8 @@ public sealed class OracleService : Plugin
     private Timer timer;
     internal CancellationTokenSource cancelSource = new();
     private OracleStatus status = OracleStatus.Unstarted;
+    private Task processingTask;
+    private readonly object lifecycleLock = new();
     private IWalletProvider walletProvider;
     private int counter;
     private NeoSystem _system;
@@ -123,41 +125,49 @@ public sealed class OracleService : Plugin
 
     public Task Start(Wallet wallet)
     {
-        if (status == OracleStatus.Running) return Task.CompletedTask;
-        DisposeProtocols();
-
-        if (wallet is null)
+        lock (lifecycleLock)
         {
-            ConsoleHelper.Warning("Please open wallet first!");
-            this.wallet = null;
-            return Task.CompletedTask;
-        }
+            if (status == OracleStatus.Running || status == OracleStatus.Stopping)
+                return processingTask ?? Task.CompletedTask;
 
-        if (!CheckOracleAvailable(_system.StoreView, out ECPoint[] oracles))
-        {
-            ConsoleHelper.Warning("The oracle service is unavailable");
-            return Task.CompletedTask;
-        }
-        if (!CheckOracleAccount(wallet, oracles))
-        {
-            ConsoleHelper.Warning("There is no oracle account in wallet");
-            return Task.CompletedTask;
-        }
+            if (wallet is null)
+            {
+                ConsoleHelper.Warning("Please open wallet first!");
+                this.wallet = null;
+                return Task.CompletedTask;
+            }
 
-        ResetCancellationSource();
-        this.wallet = wallet;
-        protocols["https"] = new OracleHttpsProtocol();
-        protocols["neofs"] = new OracleNeoFSProtocol(wallet, oracles);
-        status = OracleStatus.Running;
-        timer = new Timer(OnTimer, null, RefreshIntervalMilliSeconds, Timeout.Infinite);
-        ConsoleHelper.Info($"Oracle started");
-        return ProcessRequestsAsync(cancelSource.Token);
+            if (!CheckOracleAvailable(_system.StoreView, out ECPoint[] oracles))
+            {
+                ConsoleHelper.Warning("The oracle service is unavailable");
+                return Task.CompletedTask;
+            }
+            if (!CheckOracleAccount(wallet, oracles))
+            {
+                ConsoleHelper.Warning("There is no oracle account in wallet");
+                return Task.CompletedTask;
+            }
+
+            ResetCancellationSource();
+            DisposeProtocols();
+            this.wallet = wallet;
+            protocols["https"] = new OracleHttpsProtocol();
+            protocols["neofs"] = new OracleNeoFSProtocol(wallet, oracles);
+            status = OracleStatus.Running;
+            timer = new Timer(OnTimer, null, RefreshIntervalMilliSeconds, Timeout.Infinite);
+            ConsoleHelper.Info($"Oracle started");
+            processingTask = ProcessRequestsAsync(cancelSource.Token);
+            return processingTask;
+        }
     }
 
     private void ResetCancellationSource()
     {
         if (cancelSource.IsCancellationRequested)
+        {
+            cancelSource.Dispose();
             cancelSource = new CancellationTokenSource();
+        }
     }
 
     private void DisposeProtocols()
@@ -170,13 +180,23 @@ public sealed class OracleService : Plugin
     [ConsoleCommand("stop oracle", Category = "Oracle", Description = "Stop oracle service")]
     private void OnStop()
     {
-        cancelSource.Cancel();
-        if (timer != null)
+        lock (lifecycleLock)
         {
-            timer.Dispose();
-            timer = null;
+            if (status == OracleStatus.Stopped)
+                return;
+
+            if (status == OracleStatus.Unstarted)
+                status = OracleStatus.Stopped;
+            else if (status == OracleStatus.Running)
+                status = OracleStatus.Stopping;
+
+            cancelSource.Cancel();
+            if (timer != null)
+            {
+                timer.Dispose();
+                timer = null;
+            }
         }
-        status = OracleStatus.Stopped;
     }
 
     [ConsoleCommand("oracle status", Category = "Oracle", Description = "Show oracle status")]
@@ -201,6 +221,7 @@ public sealed class OracleService : Plugin
 
     private async void OnTimer(object state)
     {
+        var cancellation = cancelSource.Token;
         try
         {
             List<ulong> outOfDate = new();
@@ -236,7 +257,7 @@ public sealed class OracleService : Plugin
         }
         finally
         {
-            if (!cancelSource.IsCancellationRequested)
+            if (!cancellation.IsCancellationRequested)
                 timer?.Change(RefreshIntervalMilliSeconds, Timeout.Infinite);
         }
     }
@@ -362,23 +383,41 @@ public sealed class OracleService : Plugin
 
     private async Task ProcessRequestsAsync(CancellationToken cancellation)
     {
-        while (!cancellation.IsCancellationRequested)
+        try
         {
-            using (var snapshot = _system.GetSnapshotCache())
+            while (!cancellation.IsCancellationRequested)
             {
-                SyncPendingQueue(snapshot);
-                foreach (var (id, request) in NativeContract.Oracle.GetRequests(snapshot))
+                using (var snapshot = _system.GetSnapshotCache())
                 {
-                    if (cancellation.IsCancellationRequested) break;
-                    if (!finishedCache.ContainsKey(id) && (!pendingQueue.TryGetValue(id, out OracleTask task) || task.Tx is null))
-                        await ProcessRequestAsync(snapshot, request, cancellation);
+                    SyncPendingQueue(snapshot);
+                    foreach (var (id, request) in NativeContract.Oracle.GetRequests(snapshot))
+                    {
+                        if (cancellation.IsCancellationRequested) break;
+                        if (!finishedCache.ContainsKey(id) && (!pendingQueue.TryGetValue(id, out OracleTask task) || task.Tx is null))
+                            await ProcessRequestAsync(snapshot, request, cancellation);
+                    }
                 }
+                if (cancellation.IsCancellationRequested) break;
+                await Task.Delay(500, cancellation);
             }
-            if (cancellation.IsCancellationRequested) break;
-            await Task.Delay(500);
         }
-
-        status = OracleStatus.Stopped;
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            lock (lifecycleLock)
+            {
+                DisposeProtocols();
+                if (cancelSource.IsCancellationRequested)
+                {
+                    cancelSource.Dispose();
+                    cancelSource = new CancellationTokenSource();
+                }
+                processingTask = null;
+                status = OracleStatus.Stopped;
+            }
+        }
     }
 
 
@@ -404,7 +443,13 @@ public sealed class OracleService : Plugin
 
         try
         {
-            return await protocol.ProcessAsync(uri, ctsLinked.Token);
+            var result = await protocol.ProcessAsync(uri, ctsLinked.Token);
+            cancellation.ThrowIfCancellationRequested();
+            return result;
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -611,6 +656,7 @@ public sealed class OracleService : Plugin
     {
         Unstarted,
         Running,
+        Stopping,
         Stopped,
     }
 }

--- a/plugins/OracleService/OracleService.cs
+++ b/plugins/OracleService/OracleService.cs
@@ -48,7 +48,7 @@ public sealed class OracleService : Plugin
     private readonly ConcurrentDictionary<ulong, OracleTask> pendingQueue = new();
     private readonly ConcurrentDictionary<ulong, DateTime> finishedCache = new();
     private Timer timer;
-    internal readonly CancellationTokenSource cancelSource = new();
+    internal CancellationTokenSource cancelSource = new();
     private OracleStatus status = OracleStatus.Unstarted;
     private IWalletProvider walletProvider;
     private int counter;
@@ -125,6 +125,7 @@ public sealed class OracleService : Plugin
     public Task Start(Wallet wallet)
     {
         if (status == OracleStatus.Running) return Task.CompletedTask;
+        ResetCancellationSource();
 
         if (wallet is null)
         {
@@ -150,7 +151,13 @@ public sealed class OracleService : Plugin
         status = OracleStatus.Running;
         timer = new Timer(OnTimer, null, RefreshIntervalMilliSeconds, Timeout.Infinite);
         ConsoleHelper.Info($"Oracle started");
-        return ProcessRequestsAsync();
+        return ProcessRequestsAsync(cancelSource.Token);
+    }
+
+    private void ResetCancellationSource()
+    {
+        if (cancelSource.IsCancellationRequested)
+            cancelSource = new CancellationTokenSource();
     }
 
     [ConsoleCommand("stop oracle", Category = "Oracle", Description = "Stop oracle service")]
@@ -287,13 +294,13 @@ public sealed class OracleService : Plugin
         await Task.WhenAll(tasks);
     }
 
-    private async Task ProcessRequestAsync(DataCache snapshot, OracleRequest req)
+    private async Task ProcessRequestAsync(DataCache snapshot, OracleRequest req, CancellationToken cancellation)
     {
         PluginLogger?.Information("Process oracle request start: {OriginalTxid} <{Url}>", req.OriginalTxid, req.Url);
 
         uint height = NativeContract.Ledger.CurrentIndex(snapshot) + 1;
 
-        (OracleResponseCode code, string data) = await ProcessUrlAsync(req.Url);
+        (OracleResponseCode code, string data) = await ProcessUrlAsync(req.Url, cancellation);
 
         PluginLogger?.Information("Process oracle request end: {OriginalTxid} <{Url}>, responseCode:{ResponseCode}, response:{Response}",
             req.OriginalTxid, req.Url, code, data);
@@ -346,21 +353,21 @@ public sealed class OracleService : Plugin
         }
     }
 
-    private async Task ProcessRequestsAsync()
+    private async Task ProcessRequestsAsync(CancellationToken cancellation)
     {
-        while (!cancelSource.IsCancellationRequested)
+        while (!cancellation.IsCancellationRequested)
         {
             using (var snapshot = _system.GetSnapshotCache())
             {
                 SyncPendingQueue(snapshot);
                 foreach (var (id, request) in NativeContract.Oracle.GetRequests(snapshot))
                 {
-                    if (cancelSource.IsCancellationRequested) break;
+                    if (cancellation.IsCancellationRequested) break;
                     if (!finishedCache.ContainsKey(id) && (!pendingQueue.TryGetValue(id, out OracleTask task) || task.Tx is null))
-                        await ProcessRequestAsync(snapshot, request);
+                        await ProcessRequestAsync(snapshot, request, cancellation);
                 }
             }
-            if (cancelSource.IsCancellationRequested) break;
+            if (cancellation.IsCancellationRequested) break;
             await Task.Delay(500);
         }
 
@@ -378,7 +385,7 @@ public sealed class OracleService : Plugin
         }
     }
 
-    private async Task<(OracleResponseCode, string)> ProcessUrlAsync(string url)
+    private async Task<(OracleResponseCode, string)> ProcessUrlAsync(string url, CancellationToken cancellation)
     {
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
             return (OracleResponseCode.Error, $"Invalid url:<{url}>");
@@ -386,7 +393,7 @@ public sealed class OracleService : Plugin
             return (OracleResponseCode.ProtocolNotSupported, $"Invalid Protocol:<{url}>");
 
         using CancellationTokenSource ctsTimeout = new(OracleSettings.Default.MaxOracleTimeout);
-        using CancellationTokenSource ctsLinked = CancellationTokenSource.CreateLinkedTokenSource(cancelSource.Token, ctsTimeout.Token);
+        using CancellationTokenSource ctsLinked = CancellationTokenSource.CreateLinkedTokenSource(cancellation, ctsTimeout.Token);
 
         try
         {
@@ -521,9 +528,14 @@ public sealed class OracleService : Plugin
 
         if (CheckTxSign(snapshot, task.Tx, task.Signs) || CheckTxSign(snapshot, task.BackupTx, task.BackupSigns))
         {
-            finishedCache.TryAdd(requestId, new DateTime());
+            MarkRequestFinished(requestId);
             pendingQueue.TryRemove(requestId, out _);
         }
+    }
+
+    private void MarkRequestFinished(ulong requestId)
+    {
+        finishedCache.TryAdd(requestId, TimeProvider.Current.UtcNow);
     }
 
     public static byte[] Filter(string input, string filterArgs)

--- a/tests/Neo.Plugins.OracleService.Tests/TestBlockchain.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/TestBlockchain.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Akka.Actor;
+using Neo.Cryptography;
 using Neo.Extensions;
 using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
@@ -105,6 +106,65 @@ public static class TestBlockchain
         engine.SnapshotCache.Commit();
         var result = (VM.Types.Array)engine.ResultStack.Peek();
         return new UInt160(result[2].GetSpan());
+    }
+
+    public static void DesignateOracleRole()
+    {
+        byte[] script;
+        using (ScriptBuilder sb = new())
+        {
+            sb.EmitDynamicCall(NativeContract.RoleManagement.Hash, "designateAsRole",
+                [Role.Oracle,
+                    new ContractParameter()
+                    {
+                        Type = ContractParameterType.Array,
+                        Value = TestUtils.settings.StandbyCommittee.Select(
+                            p => new ContractParameter() { Type = ContractParameterType.PublicKey, Value = p }).ToList()
+                    }]);
+            script = sb.ToArray();
+        }
+
+        Transaction[] txs = [
+            new Transaction
+            {
+                Nonce = 233,
+                ValidUntilBlock = NativeContract.Ledger.CurrentIndex(s_theNeoSystem.GetSnapshotCache()) + s_theNeoSystem.Settings.MaxValidUntilBlockIncrement,
+                Signers = [new Signer() { Account = TestUtils.MultisigScriptHash, Scopes = WitnessScope.CalledByEntry }],
+                Attributes = [],
+                Script = script,
+                NetworkFee = 1000_0000,
+                SystemFee = 2_0000_0000,
+                Witnesses = []
+            }
+        ];
+        byte[] signature = txs[0].Sign(s_walletAccount.GetKey(), TestUtils.settings.Network);
+        txs[0].Witnesses = [new Witness
+        {
+            InvocationScript = new byte[] { (byte)OpCode.PUSHDATA1, (byte)signature.Length }.Concat(signature).ToArray(),
+            VerificationScript = TestUtils.MultisigScript,
+        }];
+        var block = new Block
+        {
+            Header = new Header
+            {
+                Version = 0,
+                PrevHash = s_theNeoSystem.GenesisBlock.Hash,
+                MerkleRoot = null!,
+                Timestamp = s_theNeoSystem.GenesisBlock.Timestamp + 15_000,
+                Index = 1,
+                NextConsensus = s_theNeoSystem.GenesisBlock.NextConsensus,
+                Witness = null!
+            },
+            Transactions = txs,
+        };
+        block.Header.MerkleRoot ??= MerkleTree.ComputeRoot(block.Transactions.Select(t => t.Hash).ToArray());
+        signature = block.Sign(s_walletAccount.GetKey(), TestUtils.settings.Network);
+        block.Header.Witness = new Witness
+        {
+            InvocationScript = new byte[] { (byte)OpCode.PUSHDATA1, (byte)signature.Length }.Concat(signature).ToArray(),
+            VerificationScript = TestUtils.MultisigScript,
+        };
+        s_theNeoSystem.Blockchain.Ask(block, cancellationToken: CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
     internal static void ResetStore()

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
@@ -12,6 +12,7 @@
 using Neo.Cryptography.ECC;
 using Neo.Extensions;
 using Neo.Network.P2P.Payloads;
+using Neo.Plugins.OracleService.Protocols;
 using Neo.SmartContract.Native;
 using System.Collections.Concurrent;
 using System.Reflection;
@@ -123,6 +124,7 @@ public class UT_OracleService
     {
         ResetStore();
         InitializeContract();
+        DesignateOracleRole();
 
         var oracle = new OracleService();
         SetPrivateField(oracle, "_system", s_theNeoSystem);
@@ -148,6 +150,34 @@ public class UT_OracleService
         }
     }
 
+    [TestMethod]
+    public async Task TestStartDisposesStaleProtocols()
+    {
+        ResetStore();
+        InitializeContract();
+        DesignateOracleRole();
+
+        var oracle = new OracleService();
+        var protocol = new TrackingProtocol();
+        SetPrivateField(oracle, "_system", s_theNeoSystem);
+        GetPrivateField<Dictionary<string, IOracleProtocol>>(oracle, "protocols")["stale"] = protocol;
+
+        Task run = Task.CompletedTask;
+        try
+        {
+            run = oracle.Start(s_wallet);
+            await Task.Delay(100);
+
+            Assert.IsTrue(protocol.Disposed);
+        }
+        finally
+        {
+            StopOracle(oracle);
+            await run.WaitAsync(TimeSpan.FromSeconds(5));
+            oracle.Dispose();
+        }
+    }
+
     private static T GetPrivateField<T>(object instance, string name)
     {
         return (T)instance.GetType()
@@ -167,5 +197,24 @@ public class UT_OracleService
         typeof(OracleService)
             .GetMethod("OnStop", BindingFlags.Instance | BindingFlags.NonPublic)!
             .Invoke(oracle, []);
+    }
+
+    private sealed class TrackingProtocol : IOracleProtocol
+    {
+        public bool Disposed { get; private set; }
+
+        public void Configure()
+        {
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+
+        public Task<(OracleResponseCode, string)> ProcessAsync(Uri uri, CancellationToken cancellation)
+        {
+            return Task.FromResult((OracleResponseCode.Success, string.Empty));
+        }
     }
 }

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
@@ -123,8 +123,10 @@ public class UT_OracleService
         InitializeContract();
         DesignateOracleRole();
 
-        var oracle = new OracleService();
-        oracle._system = s_theNeoSystem;
+        var oracle = new OracleService
+        {
+            _system = s_theNeoSystem
+        };
         Task firstRun = Task.CompletedTask;
         Task secondRun = Task.CompletedTask;
 

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
@@ -13,6 +13,9 @@ using Neo.Cryptography.ECC;
 using Neo.Extensions;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Native;
+using System.Collections.Concurrent;
+using System.Reflection;
+using static Neo.Plugins.OracleService.Tests.TestBlockchain;
 
 namespace Neo.Plugins.OracleService.Tests;
 
@@ -97,5 +100,72 @@ public class UT_OracleService
         Assert.AreEqual(OracleResponseCode.InsufficientFunds, response.Code);
         Assert.AreEqual(2197650, tx.NetworkFee);
         Assert.AreEqual(7802350, tx.SystemFee);
+    }
+
+    [TestMethod]
+    public void TestMarkRequestFinishedUsesCurrentTimestamp()
+    {
+        var oracle = new OracleService();
+        var markRequestFinished = typeof(OracleService).GetMethod("MarkRequestFinished", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(markRequestFinished);
+
+        var before = TimeProvider.Current.UtcNow;
+        markRequestFinished.Invoke(oracle, [1ul]);
+        var after = TimeProvider.Current.UtcNow;
+
+        var finishedCache = GetPrivateField<ConcurrentDictionary<ulong, DateTime>>(oracle, "finishedCache");
+        Assert.IsTrue(finishedCache.TryGetValue(1ul, out var timestamp));
+        Assert.IsTrue(timestamp >= before && timestamp <= after);
+    }
+
+    [TestMethod]
+    public async Task TestStartAfterStopUsesFreshCancellationSource()
+    {
+        ResetStore();
+        InitializeContract();
+
+        var oracle = new OracleService();
+        SetPrivateField(oracle, "_system", s_theNeoSystem);
+        Task secondRun = Task.CompletedTask;
+
+        try
+        {
+            _ = oracle.Start(s_wallet);
+            await Task.Delay(100);
+            StopOracle(oracle);
+
+            secondRun = oracle.Start(s_wallet);
+            await Task.Delay(100);
+
+            var cancelSource = GetPrivateField<CancellationTokenSource>(oracle, "cancelSource");
+            Assert.IsFalse(cancelSource.IsCancellationRequested);
+        }
+        finally
+        {
+            StopOracle(oracle);
+            await secondRun.WaitAsync(TimeSpan.FromSeconds(5));
+            oracle.Dispose();
+        }
+    }
+
+    private static T GetPrivateField<T>(object instance, string name)
+    {
+        return (T)instance.GetType()
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(instance)!;
+    }
+
+    private static void SetPrivateField(object instance, string name, object value)
+    {
+        instance.GetType()
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(instance, value);
+    }
+
+    private static void StopOracle(OracleService oracle)
+    {
+        typeof(OracleService)
+            .GetMethod("OnStop", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(oracle, []);
     }
 }

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
@@ -128,13 +128,15 @@ public class UT_OracleService
 
         var oracle = new OracleService();
         SetPrivateField(oracle, "_system", s_theNeoSystem);
+        Task firstRun = Task.CompletedTask;
         Task secondRun = Task.CompletedTask;
 
         try
         {
-            _ = oracle.Start(s_wallet);
+            firstRun = oracle.Start(s_wallet);
             await Task.Delay(100);
             StopOracle(oracle);
+            await firstRun.WaitAsync(TimeSpan.FromSeconds(5));
 
             secondRun = oracle.Start(s_wallet);
             await Task.Delay(100);
@@ -148,6 +150,26 @@ public class UT_OracleService
             await secondRun.WaitAsync(TimeSpan.FromSeconds(5));
             oracle.Dispose();
         }
+    }
+
+    [TestMethod]
+    public void TestStartWhileStoppingDoesNotResetCurrentRun()
+    {
+        var oracle = new OracleService();
+        var statusType = typeof(OracleService).GetNestedType("OracleStatus", BindingFlags.NonPublic);
+        Assert.IsNotNull(statusType);
+
+        var currentRun = Task.CompletedTask;
+        SetPrivateField(oracle, "status", Enum.Parse(statusType, "Stopping"));
+        SetPrivateField(oracle, "processingTask", currentRun);
+        var cancellationSource = GetPrivateField<CancellationTokenSource>(oracle, "cancelSource");
+
+        Task returnedRun = oracle.Start(null!);
+
+        Assert.AreSame(currentRun, returnedRun);
+        Assert.AreSame(cancellationSource, GetPrivateField<CancellationTokenSource>(oracle, "cancelSource"));
+        SetPrivateField(oracle, "status", Enum.Parse(statusType, "Stopped"));
+        oracle.Dispose();
     }
 
     [TestMethod]

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
@@ -15,7 +15,6 @@ using Neo.Network.P2P.Payloads;
 using Neo.Plugins.OracleService.Protocols;
 using Neo.SmartContract.Native;
 using System.Collections.Concurrent;
-using System.Reflection;
 using static Neo.Plugins.OracleService.Tests.TestBlockchain;
 
 namespace Neo.Plugins.OracleService.Tests;
@@ -107,14 +106,12 @@ public class UT_OracleService
     public void TestMarkRequestFinishedUsesCurrentTimestamp()
     {
         var oracle = new OracleService();
-        var markRequestFinished = typeof(OracleService).GetMethod("MarkRequestFinished", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.IsNotNull(markRequestFinished);
 
         var before = TimeProvider.Current.UtcNow;
-        markRequestFinished.Invoke(oracle, [1ul]);
+        oracle.MarkRequestFinished(1ul);
         var after = TimeProvider.Current.UtcNow;
 
-        var finishedCache = GetPrivateField<ConcurrentDictionary<ulong, DateTime>>(oracle, "finishedCache");
+        var finishedCache = oracle.finishedCache;
         Assert.IsTrue(finishedCache.TryGetValue(1ul, out var timestamp));
         Assert.IsTrue(timestamp >= before && timestamp <= after);
     }
@@ -127,7 +124,7 @@ public class UT_OracleService
         DesignateOracleRole();
 
         var oracle = new OracleService();
-        SetPrivateField(oracle, "_system", s_theNeoSystem);
+        oracle._system = s_theNeoSystem;
         Task firstRun = Task.CompletedTask;
         Task secondRun = Task.CompletedTask;
 
@@ -141,8 +138,7 @@ public class UT_OracleService
             secondRun = oracle.Start(s_wallet);
             await Task.Delay(100);
 
-            var cancelSource = GetPrivateField<CancellationTokenSource>(oracle, "cancelSource");
-            Assert.IsFalse(cancelSource.IsCancellationRequested);
+            Assert.IsFalse(oracle.cancelSource.IsCancellationRequested);
         }
         finally
         {
@@ -156,19 +152,17 @@ public class UT_OracleService
     public void TestStartWhileStoppingDoesNotResetCurrentRun()
     {
         var oracle = new OracleService();
-        var statusType = typeof(OracleService).GetNestedType("OracleStatus", BindingFlags.NonPublic);
-        Assert.IsNotNull(statusType);
 
         var currentRun = Task.CompletedTask;
-        SetPrivateField(oracle, "status", Enum.Parse(statusType, "Stopping"));
-        SetPrivateField(oracle, "processingTask", currentRun);
-        var cancellationSource = GetPrivateField<CancellationTokenSource>(oracle, "cancelSource");
+        oracle.status = OracleService.OracleStatus.Stopping;
+        oracle.processingTask = currentRun;
+        var cancellationSource = oracle.cancelSource;
 
         Task returnedRun = oracle.Start(null!);
 
         Assert.AreSame(currentRun, returnedRun);
-        Assert.AreSame(cancellationSource, GetPrivateField<CancellationTokenSource>(oracle, "cancelSource"));
-        SetPrivateField(oracle, "status", Enum.Parse(statusType, "Stopped"));
+        Assert.AreSame(cancellationSource, oracle.cancelSource);
+        oracle.status = OracleService.OracleStatus.Stopped;
         oracle.Dispose();
     }
 
@@ -181,8 +175,8 @@ public class UT_OracleService
 
         var oracle = new OracleService();
         var protocol = new TrackingProtocol();
-        SetPrivateField(oracle, "_system", s_theNeoSystem);
-        GetPrivateField<Dictionary<string, IOracleProtocol>>(oracle, "protocols")["stale"] = protocol;
+        oracle._system = s_theNeoSystem;
+        oracle.protocols["stale"] = protocol;
 
         Task run = Task.CompletedTask;
         try
@@ -200,25 +194,9 @@ public class UT_OracleService
         }
     }
 
-    private static T GetPrivateField<T>(object instance, string name)
-    {
-        return (T)instance.GetType()
-            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(instance)!;
-    }
-
-    private static void SetPrivateField(object instance, string name, object value)
-    {
-        instance.GetType()
-            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
-            .SetValue(instance, value);
-    }
-
     private static void StopOracle(OracleService oracle)
     {
-        typeof(OracleService)
-            .GetMethod("OnStop", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(oracle, []);
+        oracle.OnStop();
     }
 
     private sealed class TrackingProtocol : IOracleProtocol


### PR DESCRIPTION
## Summary
- Recreate the OracleService cancellation source when an operator starts the service again after `stop oracle`.
- Keep an in-progress stop from being reset by another `start oracle` command before the previous processing task finishes.
- Dispose stale oracle protocol instances before creating fresh protocol handlers.
- Store finished oracle request timestamps using the current UTC time.
- Add regression coverage for the start-after-stop lifecycle and finished request cache timestamps.

## Testing
- `dotnet test tests/Neo.Plugins.OracleService.Tests/Neo.Plugins.OracleService.Tests.csproj -c Release --no-restore`
- `dotnet format --no-restore --verify-no-changes --include plugins/OracleService/OracleService.cs tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs`
- GitHub Actions on `9a2fd930f50541bbb5dd4674b4c60db346365ae1`: `Test (ubuntu-latest)`, `Test (windows-latest)`, `Test-with-plugins (ubuntu-latest)`, `codecov/patch`, and `codecov/project` passed.
