### PR TITLE
Fix plugin download settings

### DIFF
--- a/src/Neo.CLI/CLI/MainService.CommandLine.cs
+++ b/src/Neo.CLI/CLI/MainService.CommandLine.cs
@@ -85,7 +85,8 @@ public partial class MainService
                 Path = options.Wallet ?? tempSetting.UnlockWallet.Path,
                 Password = options.Password ?? tempSetting.UnlockWallet.Password
             },
-            Contracts = tempSetting.Contracts
+            Contracts = tempSetting.Contracts,
+            Plugins = tempSetting.Plugins
         };
         if (options.IsValid) Settings.Custom = customSetting;
     }

--- a/src/Neo.CLI/Settings.cs
+++ b/src/Neo.CLI/Settings.cs
@@ -196,7 +196,7 @@ public class ContractsSettings
 
 public class PluginsSettings
 {
-    public Uri DownloadUrl { get; init; } = new("https://api.github.com/repos/neo-project/neo/releases");
+    public Uri DownloadUrl { get; init; } = new("https://api.github.com/repos/neo-project/neo-node/releases");
     public bool Prerelease { get; init; } = false;
     public Version Version { get; init; } = Assembly.GetExecutingAssembly().GetName().Version!;
 

--- a/tests/Neo.CLI.Tests/UT_MainService_CommandLine.cs
+++ b/tests/Neo.CLI.Tests/UT_MainService_CommandLine.cs
@@ -1,0 +1,53 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_MainService_CommandLine.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Reflection;
+
+namespace Neo.CLI.Tests;
+
+[TestClass]
+public class UT_MainService_CommandLine
+{
+    [TestMethod]
+    public void TestDefaultPluginDownloadUrlUsesNeoNodeReleases()
+    {
+        Assert.AreEqual(new Uri("https://api.github.com/repos/neo-project/neo-node/releases"), new PluginsSettings().DownloadUrl);
+    }
+
+    [TestMethod]
+    public void TestCommandLineSettingsPreservePluginSettings()
+    {
+        var previousSettings = Settings.Custom;
+        var pluginDownloadUrl = new Uri("https://example.com/custom-plugin-releases");
+
+        try
+        {
+            var configuredSettings = new Settings
+            {
+                Logger = new LoggerSettings(),
+                Storage = new StorageSettings(),
+                P2P = new P2PSettings(),
+                UnlockWallet = new UnlockWalletSettings(),
+                Contracts = new ContractsSettings(),
+                Plugins = new PluginsSettings { DownloadUrl = pluginDownloadUrl }
+            };
+            var method = typeof(MainService).GetMethod("CustomApplicationSettings", BindingFlags.NonPublic | BindingFlags.Static);
+
+            method!.Invoke(null, [new CommandLineOptions { DBPath = "Data_Custom_{0}" }, configuredSettings]);
+
+            Assert.AreEqual(pluginDownloadUrl, Settings.Default.Plugins.DownloadUrl);
+        }
+        finally
+        {
+            Settings.Custom = previousSettings;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- keep configured plugin settings when command-line options rebuild Settings.Custom
- change the built-in plugin release catalog default to neo-node releases
- add CLI regression tests for the default URL and command-line settings merge

## Tests
- dotnet test tests/Neo.CLI.Tests/Neo.CLI.Tests.csproj -c Release --no-restore --logger "console;verbosity=normal"
- dotnet format --no-restore --verify-no-changes --include src/Neo.CLI/Settings.cs src/Neo.CLI/CLI/MainService.CommandLine.cs tests/Neo.CLI.Tests/UT_MainService_CommandLine.cs
- git diff --check