### PR TITLE
Ignore duplicate future state roots

### DIFF
--- a/plugins/StateService/Storage/StateStore.cs
+++ b/plugins/StateService/Storage/StateStore.cs
@@ -109,8 +109,7 @@ class StateStore : UntypedActor
         if (LocalRootIndex is null) throw new InvalidOperationException(nameof(StateStore) + " could not get local root index");
         if (LocalRootIndex < stateRoot.Index && stateRoot.Index < LocalRootIndex + MaxCacheCount)
         {
-            _cache.Add(stateRoot.Index, stateRoot);
-            return true;
+            return _cache.TryAdd(stateRoot.Index, stateRoot);
         }
 
         using var stateSnapshot = Singleton.GetSnapshot();

--- a/tests/Neo.Plugins.StateService.Tests/UT_StatePlugin.cs
+++ b/tests/Neo.Plugins.StateService.Tests/UT_StatePlugin.cs
@@ -21,6 +21,7 @@ using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Native;
 using Neo.VM;
+using System.Reflection;
 
 namespace Neo.Plugins.StateService.Tests;
 
@@ -174,12 +175,33 @@ public class UT_StatePlugin
         Assert.IsFalse(jsonResult["truncated"]?.AsBoolean());
     }
 
+    [TestMethod]
+    public void TestDuplicateFutureStateRoot_ShouldBeIgnored()
+    {
+        var futureRoot = new StateRoot
+        {
+            Version = StateRoot.CurrentVersion,
+            Index = 2,
+            RootHash = UInt256.Parse(RootHashHex),
+            Witness = Witness.Empty
+        };
+
+        Assert.IsTrue(AddStateRoot(futureRoot));
+        Assert.IsFalse(AddStateRoot(futureRoot));
+    }
+
     private static void SetupMockStateRoot(uint index, UInt256 rootHash)
     {
         var stateRoot = new StateRoot { Index = index, RootHash = rootHash, Witness = Witness.Empty };
         using var store = StateStore.Singleton.GetSnapshot();
         store.AddLocalStateRoot(stateRoot);
         store.Commit();
+    }
+
+    private static bool AddStateRoot(StateRoot stateRoot)
+    {
+        var method = typeof(StateStore).GetMethod("OnNewStateRoot", BindingFlags.Instance | BindingFlags.NonPublic);
+        return (bool)method!.Invoke(StateStore.Singleton, [stateRoot])!;
     }
 
     private static UInt256 SetupMockContractAndStorage(UInt160 scriptHash)
@@ -229,4 +251,3 @@ public class UT_StatePlugin
         return trie.Root.Hash;
     }
 }
-


### PR DESCRIPTION
## Summary
- ignore duplicate future state roots instead of throwing from the pending cache
- add a StateService regression test for repeated future state root handling

## Tests
- dotnet test tests/Neo.Plugins.StateService.Tests/Neo.Plugins.StateService.Tests.csproj -c Release --no-restore --logger "console;verbosity=normal"
- dotnet format --no-restore --verify-no-changes --include plugins/StateService/Storage/StateStore.cs tests/Neo.Plugins.StateService.Tests/UT_StatePlugin.cs
- git diff --check