### PR TITLE
Fix known docker issue

### DIFF
--- a/src/Neo.CLI/Docker/.gitignore
+++ b/src/Neo.CLI/Docker/.gitignore
@@ -1,0 +1,32 @@
+
+#Ignore thumbnails created by Windows
+Thumbs.db
+#Ignore files built by Visual Studio
+*.obj
+*.exe
+*.pdb
+*.user
+*.aps
+*.pch
+*.vspscc
+*_i.c
+*_p.c
+*.ncb
+*.suo
+*.tlb
+*.tlh
+*.bak
+*.cache
+*.ilk
+*.log
+[Bb]in
+[Dd]ebug*/
+*.lib
+*.sbr
+obj/
+[Rr]elease*/
+_ReSharper*/
+[Tt]est[Rr]esult*
+.vs/
+#Nuget packages folder
+packages/

--- a/src/Neo.CLI/Docker/Dockerfile
+++ b/src/Neo.CLI/Docker/Dockerfile
@@ -12,11 +12,12 @@ RUN apt-get update && apt-get install -y \
     libsqlite3-dev \
     libunwind8-dev \
     screen \
+    dos2unix \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /neo
 COPY prepare-node.sh .
-RUN chmod +x prepare-node.sh
+RUN dos2unix prepare-node.sh && chmod +x prepare-node.sh
 
 ARG CLI_VERSION=v3.9.2
 ARG PLUGIN_VERSION=
@@ -28,5 +29,5 @@ RUN if [ -z "$PLUGIN_VERSION" ]; then \
 
 RUN sed -i 's/"BindAddress":[^,]*/"BindAddress": "0.0.0.0"/' neo-cli/Plugins/RpcServer/RpcServer.json
 COPY start.sh .
-RUN chmod -R +x ./neo-cli
+RUN dos2unix start.sh && chmod -R +x ./neo-cli && chmod +x start.sh
 ENTRYPOINT ["sh", "./start.sh"]

--- a/src/Neo.CLI/Docker/start.sh
+++ b/src/Neo.CLI/Docker/start.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-# Start CLI in background, log output to neo.log
-screen -dmS neo bash -c "./neo-cli/neo-cli > neo.log 2>&1"
+cd /neo
+
+rm -f neo.log
+
+screen -L -Logfile neo.log -dmS neo ./neo-cli/neo-cli
 
 while [ ! -f neo.log ]; do
   sleep 0.5
 done
 
-# Timely check log
 tail -f neo.log


### PR DESCRIPTION
Fix two Docker build/runtime issues for neo-cli: 
1. Shell scripts checked out with Windows `CRLF` line endings broke `prepare-node.sh` inside the Linux container (causing apt/wget failures and shell syntax errors).
2. `start.sh` was launching neo-cli with stdout redirected to a log file, which disabled its interactive TTY mode so `screen -r neo` couldn't accept any commands.