### PR TITLE
Check `MaxFee` during RPC.CancelTransaction

### DIFF
--- a/plugins/RpcServer/RpcServer.Wallet.cs
+++ b/plugins/RpcServer/RpcServer.Wallet.cs
@@ -493,7 +493,6 @@ partial class RpcServer
         if (!transContext.Completed) return transContext.ToJson();
 
         tx.Witnesses = transContext.GetWitnesses();
-        EnsureNetworkFee(snapshot, tx);
         return SignAndRelay(snapshot, tx);
     }
 
@@ -604,7 +603,6 @@ partial class RpcServer
         if (!transContext.Completed) return transContext.ToJson();
 
         tx.Witnesses = transContext.GetWitnesses();
-        EnsureNetworkFee(snapshot, tx);
         return SignAndRelay(snapshot, tx);
     }
 
@@ -661,16 +659,7 @@ partial class RpcServer
             return transContext.ToJson();
 
         tx.Witnesses = transContext.GetWitnesses();
-        EnsureNetworkFee(snapshot, tx);
         return SignAndRelay(snapshot, tx);
-    }
-
-    private void EnsureNetworkFee(StoreCache snapshot, Transaction tx)
-    {
-        long calFee = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot) + 100000;
-        if (tx.NetworkFee < calFee)
-            tx.NetworkFee = calFee;
-        (tx.NetworkFee <= settings.MaxFee).True_Or(RpcError.WalletFeeLimit);
     }
 
     /// <summary>
@@ -811,7 +800,6 @@ partial class RpcServer
 
             tx.NetworkFee += (long)decimalExtraFee.Value;
         }
-        EnsureNetworkFee(snapshot, tx);
         return SignAndRelay(snapshot, tx);
     }
 
@@ -956,6 +944,12 @@ partial class RpcServer
         if (context.Completed)
         {
             tx.Witnesses = context.GetWitnesses();
+            // Check MaxFee
+            long calFee = tx.Size * NativeContract.Policy.GetFeePerByte(snapshot) + 100000;
+            if (tx.NetworkFee < calFee)
+                tx.NetworkFee = calFee;
+            (tx.NetworkFee <= settings.MaxFee).True_Or(RpcError.WalletFeeLimit);
+            // Relay it
             var relayResult = system.Blockchain.Ask<Blockchain.RelayResult>(tx, TimeSpan.FromSeconds(30)).Result;
             // GetRelayResult throws RpcException for any non-Succeed reason; its JObject return value
             // (only { "hash": ... }) is discarded because wallet RPCs return the full tx JSON.

--- a/plugins/RpcServer/RpcServer.Wallet.cs
+++ b/plugins/RpcServer/RpcServer.Wallet.cs
@@ -780,7 +780,9 @@ partial class RpcServer
     protected internal virtual JToken CancelTransaction(UInt256 txid, Address[] signers, string? extraFee = null)
     {
         var wallet = CheckWallet();
-        NativeContract.Ledger.GetTransactionState(system.StoreView, txid)
+        using var snapshot = system.GetSnapshotCache();
+
+        NativeContract.Ledger.GetTransactionState(snapshot, txid)
             .Null_Or(RpcErrorFactory.AlreadyExists("This tx is already confirmed, can't be cancelled."));
 
         if (signers is null || signers.Length == 0) throw new RpcException(RpcErrorFactory.BadRequest("No signer."));
@@ -795,7 +797,7 @@ partial class RpcServer
         };
 
         tx = Result.Ok_Or(
-            () => wallet.MakeTransaction(system.StoreView, new[] { (byte)OpCode.RET }, noneSigners[0].Account, noneSigners, conflict),
+            () => wallet.MakeTransaction(snapshot, new[] { (byte)OpCode.RET }, noneSigners[0].Account, noneSigners, conflict),
             RpcError.InsufficientFunds, true);
         if (system.MemPool.TryGetValue(txid, out var conflictTx))
         {
@@ -803,13 +805,14 @@ partial class RpcServer
         }
         else if (extraFee is not null)
         {
-            var descriptor = new AssetDescriptor(system.StoreView, system.Settings, NativeContract.GAS.Hash);
+            var descriptor = new AssetDescriptor(snapshot, system.Settings, NativeContract.GAS.Hash);
             (BigDecimal.TryParse(extraFee, descriptor.Decimals, out var decimalExtraFee) && decimalExtraFee.Sign > 0)
                 .True_Or(RpcErrorFactory.InvalidParams("Incorrect amount format."));
 
             tx.NetworkFee += (long)decimalExtraFee.Value;
         }
-        return SignAndRelay(system.StoreView, tx);
+        EnsureNetworkFee(snapshot, tx);
+        return SignAndRelay(snapshot, tx);
     }
 
     /// <summary>

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
@@ -937,7 +937,6 @@ partial class UT_RpcServer
     }
 
     [TestMethod]
-    [Obsolete]
     public void TestCancelTransaction()
     {
         TestUtilOpenWallet();


### PR DESCRIPTION
This pull request refactors the `CancelTransaction` method in `RpcServer.Wallet.cs` to consistently use a snapshot of the system state rather than the live `StoreView`. This change ensures more reliable and isolated transaction handling by operating on a consistent view of the blockchain state during cancellation operations.

**Refactoring for consistent snapshot usage:**

* Replaced usage of `system.StoreView` with a locally scoped `snapshot` (created via `system.GetSnapshotCache()`) throughout the `CancelTransaction` method to ensure all transaction checks and operations are performed on a consistent state. [[1]](diffhunk://#diff-117ada1714c3ef54ab7a33751d40147a8bcb45c8f47ad9a664eb15a277c7c353L783-R785) [[2]](diffhunk://#diff-117ada1714c3ef54ab7a33751d40147a8bcb45c8f47ad9a664eb15a277c7c353L798-R815)
* Updated calls to `MakeTransaction`, `AssetDescriptor`, `SignAndRelay`, and introduced `EnsureNetworkFee` to use the new `snapshot` variable, further enforcing the use of a consistent state during transaction cancellation.