### PR TITLE
RpcServer: always mock transaction and signers for 'invoke*' handlers

### DIFF
--- a/plugins/RpcServer/Session.cs
+++ b/plugins/RpcServer/Session.cs
@@ -29,7 +29,9 @@ class Session : IDisposable
     {
         Random random = new();
         Snapshot = system.GetSnapshotCache();
-        var tx = signers == null ? null : new Transaction
+        if (signers == null)
+            signers = new[] { new Signer { Account = UInt160.Zero, Scopes = WitnessScope.None } };
+        var tx = new Transaction
         {
             Version = 0,
             Nonce = (uint)random.Next(),


### PR DESCRIPTION
1. Always mock script container (transaction) for 'invokefunction' and 'invokescript' execution. It allows to avoid exceptions during script container related interops handling and native methods handling (System.Runtime.GetScriptContainer and etc.). Ref. https://github.com/nspcc-dev/neo-go/blob/c41054fb7c40e6312e227e49f7cc3f148f113495/pkg/services/rpcsrv/server.go#L2224

2. Mock the list of transaction signers if not provided. Use dummy sender with zero address and none scope to avoid exception during signer/senders related interops handling. Ref. https://github.com/nspcc-dev/neo-go/blob/c41054fb7c40e6312e227e49f7cc3f148f113495/pkg/services/rpcsrv/server.go#L2240

Close https://github.com/nspcc-dev/neo-go/issues/4290.