### PR TITLE
[N4] Port Docker use to N4

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0.101-noble
+
+# Install required dependencies for LevelDB and SQLite
+RUN apt-get update && \
+    apt-get install -y \
+    libleveldb-dev \
+    sqlite3 \
+    libsqlite3-dev \
+    librocksdb-dev \
+    libsnappy-dev \
+    libunwind8-dev \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Neo Node",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "features": {},
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit"
+      ]
+    }
+  },
+  "remoteUser": "root",
+  "postCreateCommand": "dotnet restore"
+}
+

--- a/src/Neo.CLI/Docker/.gitignore
+++ b/src/Neo.CLI/Docker/.gitignore
@@ -1,0 +1,32 @@
+
+#Ignore thumbnails created by Windows
+Thumbs.db
+#Ignore files built by Visual Studio
+*.obj
+*.exe
+*.pdb
+*.user
+*.aps
+*.pch
+*.vspscc
+*_i.c
+*_p.c
+*.ncb
+*.suo
+*.tlb
+*.tlh
+*.bak
+*.cache
+*.ilk
+*.log
+[Bb]in
+[Dd]ebug*/
+*.lib
+*.sbr
+obj/
+[Rr]elease*/
+_ReSharper*/
+[Tt]est[Rr]esult*
+.vs/
+#Nuget packages folder
+packages/

--- a/src/Neo.CLI/Docker/Dockerfile
+++ b/src/Neo.CLI/Docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS Build
+RUN apt-get update && apt-get install -y \
+    net-tools \
+    telnet \
+    bash-completion \
+    wget \
+    curl \
+    lrzsz \
+    zip \
+    unzip \
+    sqlite3 \
+    libsqlite3-dev \
+    libunwind8-dev \
+    screen \
+    dos2unix \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /neo
+COPY prepare-node.sh .
+RUN dos2unix prepare-node.sh && chmod +x prepare-node.sh
+
+ARG CLI_VERSION=v3.9.2
+ARG PLUGIN_VERSION=
+RUN if [ -z "$PLUGIN_VERSION" ]; then \
+        ./prepare-node.sh $CLI_VERSION; \
+    else \
+        ./prepare-node.sh $CLI_VERSION $PLUGIN_VERSION; \
+    fi
+
+RUN sed -i 's/"BindAddress":[^,]*/"BindAddress": "0.0.0.0"/' neo-cli/Plugins/RpcServer/RpcServer.json
+COPY start.sh .
+RUN dos2unix start.sh && chmod -R +x ./neo-cli && chmod +x start.sh
+ENTRYPOINT ["sh", "./start.sh"]

--- a/src/Neo.CLI/Docker/Dockerfile
+++ b/src/Neo.CLI/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS Build
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 RUN apt-get update && apt-get install -y \
     net-tools \
     telnet \
@@ -19,7 +19,7 @@ WORKDIR /neo
 COPY prepare-node.sh .
 RUN dos2unix prepare-node.sh && chmod +x prepare-node.sh
 
-ARG CLI_VERSION=v3.9.2
+ARG CLI_VERSION=v4.0.0
 ARG PLUGIN_VERSION=
 RUN if [ -z "$PLUGIN_VERSION" ]; then \
         ./prepare-node.sh $CLI_VERSION; \

--- a/src/Neo.CLI/Docker/README.md
+++ b/src/Neo.CLI/Docker/README.md
@@ -1,0 +1,52 @@
+# Neo CLI Docker Usage Examples
+
+## Example 1: Install CLI v3.9.2 (with matching plugins)
+
+```bash
+# Build the image (v3.9.2 is the default)
+docker build -t v3.9.2 .
+
+# Run the container
+docker run -d -p 10332:10332 --name neo-node v3.9.2
+
+# Enter the container and test
+docker exec -it neo-node bash
+curl -X POST http://localhost:10332 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}'
+```
+
+## Example 2: Install CLI v3.9.2 with Plugin v3.9.0
+
+```bash
+# Build the image
+docker build -t v3.9.2-plugins-3.9.0 --build-arg PLUGIN_VERSION=v3.9.0 .
+
+# Run the container
+docker run -d -p 10332:10332 --name neo-node v3.9.2-plugins-3.9.0
+
+# Enter the container and test
+docker exec -it neo-node bash
+curl -X POST http://localhost:10332 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}'
+```
+
+## Example 3: Install CLI v3.10.0 (with matching plugins)
+
+```bash
+# Build the image
+docker build -t v3.10.0 --build-arg CLI_VERSION=v3.10.0 .
+
+# Run the container
+docker run -d -p 10332:10332 --name neo-node v3.10.0
+
+# Enter the container and test
+docker exec -it neo-node bash
+curl -X POST http://localhost:10332 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}'
+```
+
+## Quick Test Command
+
+Once inside the container, you can also use:
+```bash
+curl http://localhost:10332 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}'
+```
+
+This will return the current block count, confirming the CLI is running and responding to RPC calls.

--- a/src/Neo.CLI/Docker/README.md
+++ b/src/Neo.CLI/Docker/README.md
@@ -1,41 +1,41 @@
 # Neo CLI Docker Usage Examples
 
-## Example 1: Install CLI v3.9.2 (with matching plugins)
+## Example 1: Install CLI v4.0.0 (with matching plugins)
 
 ```bash
-# Build the image (v3.9.2 is the default)
-docker build -t v3.9.2 .
+# Build the image (v4.0.0 is the default)
+docker build -t v4.0.0 .
 
 # Run the container
-docker run -d -p 10332:10332 --name neo-node v3.9.2
+docker run -d -p 10332:10332 --name neo-node v4.0.0
 
 # Enter the container and test
 docker exec -it neo-node bash
 curl -X POST http://localhost:10332 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}'
 ```
 
-## Example 2: Install CLI v3.9.2 with Plugin v3.9.0
+## Example 2: Install CLI v4.0.0 with Plugin v4.0.0
 
 ```bash
 # Build the image
-docker build -t v3.9.2-plugins-3.9.0 --build-arg PLUGIN_VERSION=v3.9.0 .
+docker build -t v4.0.0-plugins-4.0.0 --build-arg PLUGIN_VERSION=v4.0.0 .
 
 # Run the container
-docker run -d -p 10332:10332 --name neo-node v3.9.2-plugins-3.9.0
+docker run -d -p 10332:10332 --name neo-node v4.0.0-plugins-4.0.0
 
 # Enter the container and test
 docker exec -it neo-node bash
 curl -X POST http://localhost:10332 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}'
 ```
 
-## Example 3: Install CLI v3.10.0 (with matching plugins)
+## Example 3: Install CLI v4.0.0 (with matching plugins)
 
 ```bash
 # Build the image
-docker build -t v3.10.0 --build-arg CLI_VERSION=v3.10.0 .
+docker build -t v4.0.0 --build-arg CLI_VERSION=v4.0.0 .
 
 # Run the container
-docker run -d -p 10332:10332 --name neo-node v3.10.0
+docker run -d -p 10332:10332 --name neo-node v4.0.0
 
 # Enter the container and test
 docker exec -it neo-node bash

--- a/src/Neo.CLI/Docker/prepare-node.sh
+++ b/src/Neo.CLI/Docker/prepare-node.sh
@@ -1,0 +1,22 @@
+echo "Downloading neo node $1"
+wget  https://github.com/neo-project/neo-node/releases/download/$1/neo-cli-linux-x64.zip
+unzip neo-cli-linux-x64.zip
+
+
+if [ -z "$2" ]; then
+    echo "Downloading plugins $1"
+    wget https://github.com/neo-project/neo-node/releases/download/$1/ApplicationLogs.zip
+    wget https://github.com/neo-project/neo-node/releases/download/$1/RpcServer.zip
+    wget https://github.com/neo-project/neo-node/releases/download/$1/TokensTracker.zip
+else
+    echo "Downloading plugins $2"
+    wget https://github.com/neo-project/neo-node/releases/download/$2/ApplicationLogs.zip
+    wget https://github.com/neo-project/neo-node/releases/download/$2/RpcServer.zip
+    wget https://github.com/neo-project/neo-node/releases/download/$2/TokensTracker.zip
+fi
+
+unzip -n ApplicationLogs.zip -d ./neo-cli/
+unzip -n RpcServer.zip -d ./neo-cli/
+unzip -n TokensTracker.zip -d ./neo-cli/
+
+echo "Node Ready!"

--- a/src/Neo.CLI/Docker/start.sh
+++ b/src/Neo.CLI/Docker/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd /neo
+
+rm -f neo.log
+
+screen -L -Logfile neo.log -dmS neo ./neo-cli/neo-cli
+
+while [ ! -f neo.log ]; do
+  sleep 0.5
+done
+
+tail -f neo.log


### PR DESCRIPTION
# Port PR related to 
https://github.com/neo-project/neo-node/pull/992
https://github.com/neo-project/neo-node/pull/1057

# Summary
- CLI docker for common usages.
- Fix two Docker build/runtime issues for neo-cli:

  - Shell scripts checked out with Windows CRLF line endings broke prepare-node.sh inside the Linux container (causing apt/wget failures and shell syntax errors).
  - start.sh was launching neo-cli with stdout redirected to a log file, which disabled its interactive TTY mode so screen -r neo couldn't accept any commands.