### PR TITLE
Fix register candidate via onNep17Payment

### DIFF
--- a/src/Neo.CLI/CLI/MainService.Vote.cs
+++ b/src/Neo.CLI/CLI/MainService.Vote.cs
@@ -17,6 +17,7 @@ using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
+using Neo.VM;
 using Neo.VM.Types;
 using Neo.Wallets;
 using System.Numerics;
@@ -67,7 +68,39 @@ partial class MainService
 
         var testGas = NativeContract.NEO.GetRegisterPrice(snapshot) + (BigInteger)Math.Pow(10, NativeContract.GAS.Decimals) * 10;
         var script = BuildNeoScript(VoteMethods.Register, publicKey);
-        SendTransaction(script, account, (long)testGas);
+        RegisterCandidateViaInvoke(script, account, snapshot, (long)testGas);
+    }
+
+    private void RegisterCandidateViaInvoke(byte[] script, UInt160 account, DataCache snapshot, long testGas)
+    {
+        var signers = CurrentWallet!.GetAccounts()
+            .Where(p => !p.Lock && !p.WatchOnly && p.ScriptHash == account && NativeContract.GAS.BalanceOf(snapshot, p.ScriptHash).Sign > 0)
+            .Select(p => new Signer { Account = p.ScriptHash, Scopes = WitnessScope.CalledByEntry })
+            .ToArray();
+
+        try
+        {
+            var tx = CurrentWallet!.MakeTransaction(snapshot, script, account, signers, maxGas: testGas);
+            ConsoleHelper.Info("Invoking script with: ", $"'{Convert.ToBase64String(tx.Script.Span)}'");
+            using (var engine = ApplicationEngine.Run(tx.Script, snapshot, container: tx, settings: NeoSystem.Settings, gas: testGas))
+            {
+                PrintExecutionOutput(engine, true);
+                if (engine.State == VMState.FAULT) return;
+            }
+
+            ConsoleHelper.Info(
+                "Network fee: ", $"{new BigDecimal((BigInteger)tx.NetworkFee, NativeContract.GAS.Decimals)}\t",
+                "Total fee: ", $"{new BigDecimal((BigInteger)(tx.SystemFee + tx.NetworkFee), NativeContract.GAS.Decimals)} GAS");
+
+            if (!ConsoleHelper.ReadUserInput("Relay tx(no|yes)").IsYes())
+                return;
+
+            SignAndSendTx(snapshot, tx);
+        }
+        catch (InvalidOperationException e)
+        {
+            ConsoleHelper.Error(GetExceptionMessage(e));
+        }
     }
 
     /// <summary>
@@ -112,7 +145,17 @@ partial class MainService
             return;
         }
 
+        using (var engine = ApplicationEngine.Run(tx.Script, snapshot, container: tx, settings: NeoSystem.Settings, gas: TestModeGas))
+        {
+            PrintExecutionOutput(engine, true);
+            if (engine.State == VMState.FAULT) return;
+        }
+
         ConsoleHelper.Info("Registering candidate via GAS transfer to NEO contract, amount: ", amount.ToString());
+        ConsoleHelper.Info(
+            "Network fee: ", $"{new BigDecimal((BigInteger)tx.NetworkFee, NativeContract.GAS.Decimals)}\t",
+            "System fee: ", $"{new BigDecimal((BigInteger)tx.SystemFee, NativeContract.GAS.Decimals)}\t",
+            "Total fee: ", $"{new BigDecimal((BigInteger)(tx.SystemFee + tx.NetworkFee), NativeContract.GAS.Decimals)} GAS");
 
         if (!ConsoleHelper.ReadUserInput("Relay tx(no|yes)").IsYes())
             return;

--- a/src/Neo.CLI/CLI/MainService.Vote.cs
+++ b/src/Neo.CLI/CLI/MainService.Vote.cs
@@ -66,7 +66,7 @@ partial class MainService
             return;
         }
 
-        var testGas = NativeContract.NEO.GetRegisterPrice(snapshot) + (BigInteger)Math.Pow(10, NativeContract.GAS.Decimals) * 10;
+        var testGas = NativeContract.NEO.GetRegisterPrice(snapshot) + BigInteger.Pow(10, NativeContract.GAS.Decimals) * 10;
         var script = BuildNeoScript(VoteMethods.Register, publicKey);
         RegisterCandidateViaInvoke(script, account, snapshot, (long)testGas);
     }

--- a/src/Neo.CLI/CLI/MainService.Vote.cs
+++ b/src/Neo.CLI/CLI/MainService.Vote.cs
@@ -13,12 +13,15 @@ using Neo.ConsoleService;
 using Neo.Cryptography.ECC;
 using Neo.Extensions;
 using Neo.Json;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
 using Neo.VM.Types;
 using Neo.Wallets;
 using System.Numerics;
 using Array = Neo.VM.Types.Array;
+using ECPoint = Neo.Cryptography.ECC.ECPoint;
 
 namespace Neo.CLI;
 
@@ -42,15 +45,79 @@ partial class MainService
     [ConsoleCommand("register candidate", Category = "Vote Commands")]
     private void OnRegisterCandidateCommand(UInt160 account)
     {
-        var testGas = NativeContract.NEO.GetRegisterPrice(NeoSystem.StoreView) + (BigInteger)Math.Pow(10, NativeContract.GAS.Decimals) * 10;
         if (NoWallet()) return;
 
         var currentAccount = GetValidAccountOrWarn(account);
         if (currentAccount == null) return;
 
         var publicKey = currentAccount.GetKey()?.PublicKey;
+        if (publicKey is null)
+        {
+            ConsoleHelper.Error("Unable to get the public key of the account.");
+            return;
+        }
+
+        var snapshot = NeoSystem.StoreView;
+        var index = NativeContract.Ledger.CurrentIndex(snapshot);
+        if (NeoSystem.Settings.IsHardforkEnabled(Hardfork.HF_Echidna, index))
+        {
+            RegisterCandidateViaNep17Payment(account, publicKey, snapshot);
+            return;
+        }
+
+        var testGas = NativeContract.NEO.GetRegisterPrice(snapshot) + (BigInteger)Math.Pow(10, NativeContract.GAS.Decimals) * 10;
         var script = BuildNeoScript(VoteMethods.Register, publicKey);
         SendTransaction(script, account, (long)testGas);
+    }
+
+    /// <summary>
+    /// Registers a candidate by transferring the register price in GAS to the NEO native contract.
+    /// This triggers <c>OnNEP17Payment</c> and avoids charging the register price as transaction system fee,
+    /// which is required when <c>MaxBlockSystemFee</c> is lower than the register price.
+    /// </summary>
+    private void RegisterCandidateViaNep17Payment(UInt160 account, ECPoint publicKey, DataCache snapshot)
+    {
+        var registerPrice = NativeContract.NEO.GetRegisterPrice(snapshot);
+        var amount = new BigDecimal((BigInteger)registerPrice, NativeContract.GAS.Decimals);
+        var gasBalance = NativeContract.GAS.BalanceOf(snapshot, account);
+        if (gasBalance < registerPrice)
+        {
+            ConsoleHelper.Error($"Insufficient GAS. Required: {amount}, available: {new BigDecimal(gasBalance, NativeContract.GAS.Decimals)}.");
+            return;
+        }
+
+        Transaction tx;
+        try
+        {
+            // OnNEP17Payment runs inside GAS.transfer callback (depth > 1), so CalledByEntry
+            // witness scope is not sufficient for RegisterInternal's CheckWitness.
+            var signers = new[]
+            {
+                new Signer { Account = account, Scopes = WitnessScope.Global }
+            };
+            tx = CurrentWallet!.MakeTransaction(snapshot, new[]
+            {
+                new TransferOutput
+                {
+                    AssetId = NativeContract.GAS.Hash,
+                    Value = amount,
+                    ScriptHash = NativeContract.NEO.Hash,
+                    Data = publicKey.EncodePoint(true)
+                }
+            }, from: account, cosigners: signers);
+        }
+        catch (InvalidOperationException e)
+        {
+            ConsoleHelper.Error(GetExceptionMessage(e));
+            return;
+        }
+
+        ConsoleHelper.Info("Registering candidate via GAS transfer to NEO contract, amount: ", amount.ToString());
+
+        if (!ConsoleHelper.ReadUserInput("Relay tx(no|yes)").IsYes())
+            return;
+
+        SignAndSendTx(snapshot, tx);
     }
 
     /// <summary>

--- a/tests/Neo.CLI.Tests/TestUtils.MainService.cs
+++ b/tests/Neo.CLI.Tests/TestUtils.MainService.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+#nullable enable
+
 using System.Reflection;
 
 namespace Neo.CLI.Tests;

--- a/tests/Neo.CLI.Tests/TestUtils.MainService.cs
+++ b/tests/Neo.CLI.Tests/TestUtils.MainService.cs
@@ -1,0 +1,42 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// TestUtils.MainService.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using System.Reflection;
+
+namespace Neo.CLI.Tests;
+
+public static partial class TestUtils
+{
+    public static void TrySet(object target, string propertyName, object value)
+    {
+        var prop = target.GetType().GetProperty(
+            propertyName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        prop?.SetValue(target, value);
+    }
+
+    public static void TrySetField(object target, string fieldName, object value)
+    {
+        var field = target.GetType().GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        field?.SetValue(target, value);
+    }
+
+    public static object? InvokeNonPublic(object target, string methodName, params object?[] args)
+    {
+        var method = target.GetType().GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.IsNotNull(method, $"Method '{methodName}' not found on type '{target.GetType().FullName}'.");
+        return method!.Invoke(target, args);
+    }
+}

--- a/tests/Neo.CLI.Tests/UT_MainService_Vote.cs
+++ b/tests/Neo.CLI.Tests/UT_MainService_Vote.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+#nullable enable
+
 using Neo.Cryptography.ECC;
 using Neo.Extensions;
 using Neo.Network.P2P.Payloads;

--- a/tests/Neo.CLI.Tests/UT_MainService_Vote.cs
+++ b/tests/Neo.CLI.Tests/UT_MainService_Vote.cs
@@ -10,7 +10,6 @@
 // modifications are permitted.
 
 using Neo.Cryptography.ECC;
-using System.Security.Cryptography;
 using Neo.Extensions;
 using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
@@ -19,6 +18,7 @@ using Neo.SmartContract.Native;
 using Neo.Wallets;
 using System.Numerics;
 using System.Reflection;
+using System.Security.Cryptography;
 using ECPoint = Neo.Cryptography.ECC.ECPoint;
 
 namespace Neo.CLI.Tests;

--- a/tests/Neo.CLI.Tests/UT_MainService_Vote.cs
+++ b/tests/Neo.CLI.Tests/UT_MainService_Vote.cs
@@ -1,0 +1,382 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_MainService_Vote.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Cryptography.ECC;
+using System.Security.Cryptography;
+using Neo.Extensions;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.SmartContract;
+using Neo.SmartContract.Native;
+using Neo.Wallets;
+using System.Numerics;
+using System.Reflection;
+using ECPoint = Neo.Cryptography.ECC.ECPoint;
+
+namespace Neo.CLI.Tests;
+
+[TestClass]
+public class UT_MainService_Vote
+{
+    private static readonly ProtocolSettings WithEchidnaAtGenesis =
+        TestProtocolSettings.Default with
+        {
+            Hardforks = TestProtocolSettings.Default.Hardforks.SetItem(Hardfork.HF_Echidna, 0),
+        };
+
+    private static readonly ProtocolSettings WithoutEchidna =
+        TestProtocolSettings.Default with
+        {
+            Hardforks = TestProtocolSettings.Default.Hardforks.SetItem(Hardfork.HF_Echidna, uint.MaxValue),
+        };
+
+    [TestMethod]
+    public void TestOnRegisterCandidateCommand_NoWallet()
+    {
+        var output = RunRegisterCandidate(new VoteTestContext(TestBlockchain.GetSystem()), relayAnswer: null);
+
+        Assert.Contains("You have to open the wallet first.", output);
+    }
+
+    [TestMethod]
+    public void TestOnRegisterCandidateCommand_AccountNotInWallet()
+    {
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        wallet.CreateAccount();
+
+        var output = RunRegisterCandidate(
+            new VoteTestContext(TestBlockchain.GetSystem(), wallet),
+            account: UInt160.Zero);
+
+        Assert.Contains("This address isn't in your wallet!", output);
+    }
+
+    [TestMethod]
+    public void TestOnRegisterCandidateCommand_LockedAccount()
+    {
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var account = wallet.CreateAccount();
+        account.Lock = true;
+
+        var output = RunRegisterCandidate(
+            new VoteTestContext(TestBlockchain.GetSystem(), wallet),
+            account: account.ScriptHash);
+
+        Assert.Contains("Locked or WatchOnly address.", output);
+    }
+
+    [TestMethod]
+    public void TestOnRegisterCandidateCommand_WatchOnlyAccount()
+    {
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var watchHash = new UInt160(RandomNumberGenerator.GetBytes(20));
+        var watchAccount = wallet.CreateAccount(watchHash);
+
+        var output = RunRegisterCandidate(
+            new VoteTestContext(TestBlockchain.GetSystem(), wallet),
+            account: watchAccount.ScriptHash);
+
+        Assert.Contains("Locked or WatchOnly address.", output);
+    }
+
+    [TestMethod]
+    public void TestOnRegisterCandidateCommand_NoPublicKey()
+    {
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var signer = TestProtocolSettings.Default.StandbyCommittee[0];
+        var contract = Contract.CreateMultiSigContract(1, new[] { signer });
+        var account = wallet.CreateAccount(contract, (KeyPair?)null);
+
+        var output = RunRegisterCandidate(
+            new VoteTestContext(TestBlockchain.GetSystem(), wallet),
+            account: account.ScriptHash);
+
+        Assert.Contains("Unable to get the public key of the account.", output);
+    }
+
+    [TestMethod]
+    public void TestOnRegisterCandidateCommand_LegacyPath_UsesInvokeInsteadOfNep17Payment()
+    {
+        var neoSystem = new TestBlockchain.TestNeoSystem(WithoutEchidna);
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var account = wallet.CreateAccount();
+        var snapshot = neoSystem.StoreView;
+        var index = NativeContract.Ledger.CurrentIndex(snapshot);
+        Assert.IsFalse(neoSystem.Settings.IsHardforkEnabled(Hardfork.HF_Echidna, index));
+
+        FundGas(neoSystem, account.ScriptHash, 100_000_000 * NativeContract.GAS.Factor);
+
+        var output = RunRegisterCandidate(
+            new VoteTestContext(neoSystem, wallet),
+            account: account.ScriptHash,
+            relayAnswer: "no");
+
+        Assert.DoesNotContain("Registering candidate via GAS transfer", output);
+        Assert.IsTrue(
+            output.Contains("Invoking script with:", StringComparison.Ordinal) ||
+            output.Contains("Insufficient GAS", StringComparison.Ordinal) ||
+            output.Contains("Error:", StringComparison.Ordinal),
+            "Legacy path should build and test-invoke a contract script instead of using NEP-17 payment.");
+    }
+
+    [TestMethod]
+    public void TestOnRegisterCandidateCommand_EchidnaPath_InsufficientGas()
+    {
+        var neoSystem = new TestBlockchain.TestNeoSystem(WithEchidnaAtGenesis);
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var account = wallet.CreateAccount();
+
+        var output = RunRegisterCandidate(
+            new VoteTestContext(neoSystem, wallet),
+            account: account.ScriptHash,
+            relayAnswer: "no");
+
+        Assert.Contains("Insufficient GAS. Required:", output);
+        Assert.DoesNotContain("Invoking script with:", output);
+    }
+
+    [TestMethod]
+    public void TestRegisterCandidateViaNep17Payment_InsufficientGas()
+    {
+        var neoSystem = new TestBlockchain.TestNeoSystem(WithEchidnaAtGenesis);
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var account = wallet.CreateAccount();
+        var publicKey = account.GetKey()!.PublicKey;
+        var snapshot = neoSystem.StoreView;
+
+        var output = RunRegisterCandidateViaNep17Payment(
+            new VoteTestContext(neoSystem, wallet),
+            account.ScriptHash,
+            publicKey,
+            snapshot,
+            relayAnswer: "no");
+
+        Assert.Contains("Insufficient GAS. Required:", output);
+    }
+
+    [TestMethod]
+    public void TestRegisterCandidateViaNep17Payment_RelayCancelled()
+    {
+        var neoSystem = new TestBlockchain.TestNeoSystem(WithEchidnaAtGenesis);
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var account = wallet.CreateAccount();
+        var publicKey = account.GetKey()!.PublicKey;
+        var snapshot = neoSystem.StoreView;
+        var registerPrice = NativeContract.NEO.GetRegisterPrice(snapshot);
+        FundGas(neoSystem, account.ScriptHash, 100_000_000 * NativeContract.GAS.Factor);
+
+        var output = RunRegisterCandidateViaNep17Payment(
+            new VoteTestContext(neoSystem, wallet),
+            account.ScriptHash,
+            publicKey,
+            snapshot,
+            relayAnswer: "no");
+
+        Assert.Contains("Registering candidate via GAS transfer to NEO contract", output);
+        Assert.DoesNotContain("Signed and relayed transaction", output);
+        Assert.DoesNotContain("Relay failed:", output);
+    }
+
+    [TestMethod]
+    public void TestRegisterCandidateViaNep17Payment_UsesGlobalWitnessScope()
+    {
+        var neoSystem = new TestBlockchain.TestNeoSystem(WithEchidnaAtGenesis);
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var account = wallet.CreateAccount();
+        var publicKey = account.GetKey()!.PublicKey;
+        var snapshot = neoSystem.StoreView;
+        var registerPrice = NativeContract.NEO.GetRegisterPrice(snapshot);
+        FundGas(neoSystem, account.ScriptHash, 100_000_000 * NativeContract.GAS.Factor);
+
+        var signers = new[]
+        {
+            new Signer { Account = account.ScriptHash, Scopes = WitnessScope.Global }
+        };
+        var tx = wallet.MakeTransaction(snapshot, new[]
+        {
+            new TransferOutput
+            {
+                AssetId = NativeContract.GAS.Hash,
+                Value = new BigDecimal((BigInteger)registerPrice, NativeContract.GAS.Decimals),
+                ScriptHash = NativeContract.NEO.Hash,
+                Data = publicKey.EncodePoint(true)
+            }
+        }, from: account.ScriptHash, cosigners: signers);
+
+        Assert.HasCount(1, tx.Signers);
+        Assert.AreEqual(account.ScriptHash, tx.Signers[0].Account);
+        Assert.AreEqual(WitnessScope.Global, tx.Signers[0].Scopes);
+    }
+
+    [TestMethod]
+    public void TestRegisterCandidateViaNep17Payment_MakeTransactionError()
+    {
+        var neoSystem = new TestBlockchain.TestNeoSystem(WithEchidnaAtGenesis);
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var account = wallet.CreateAccount();
+        var publicKey = account.GetKey()!.PublicKey;
+        var snapshot = neoSystem.StoreView;
+        var registerPrice = NativeContract.NEO.GetRegisterPrice(snapshot);
+        FundGas(neoSystem, account.ScriptHash, registerPrice);
+
+        var output = RunRegisterCandidateViaNep17Payment(
+            new VoteTestContext(neoSystem, wallet),
+            account.ScriptHash,
+            publicKey,
+            snapshot,
+            relayAnswer: "yes");
+
+        Assert.Contains("Insufficient GAS balance to cover system and network fees", output);
+        Assert.DoesNotContain("Registering candidate via GAS transfer", output);
+    }
+
+    [TestMethod]
+    public void TestRegisterCandidateViaNep17Payment_RelayedSuccessfully()
+    {
+        var neoSystem = new TestBlockchain.TestNeoSystem(WithEchidnaAtGenesis);
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var account = wallet.CreateAccount();
+        var publicKey = account.GetKey()!.PublicKey;
+        var snapshot = neoSystem.StoreView;
+        var registerPrice = NativeContract.NEO.GetRegisterPrice(snapshot);
+        FundGas(neoSystem, account.ScriptHash, 100_000_000 * NativeContract.GAS.Factor);
+
+        var output = RunRegisterCandidateViaNep17Payment(
+            new VoteTestContext(neoSystem, wallet),
+            account.ScriptHash,
+            publicKey,
+            snapshot,
+            relayAnswer: "yes");
+
+        Assert.Contains("Registering candidate via GAS transfer to NEO contract", output);
+        Assert.IsTrue(
+            output.Contains("Signed and relayed transaction", StringComparison.Ordinal) ||
+            output.Contains("Relay failed:", StringComparison.Ordinal),
+            "Relaying should be attempted after user confirmation.");
+    }
+
+    [TestMethod]
+    public void TestOnRegisterCandidateCommand_EchidnaPath_RelayCancelled()
+    {
+        var neoSystem = new TestBlockchain.TestNeoSystem(WithEchidnaAtGenesis);
+        var wallet = TestUtils.GenerateTestWallet("test_pwd");
+        var account = wallet.CreateAccount();
+        var snapshot = neoSystem.StoreView;
+        var registerPrice = NativeContract.NEO.GetRegisterPrice(snapshot);
+        FundGas(neoSystem, account.ScriptHash, 100_000_000 * NativeContract.GAS.Factor);
+
+        var output = RunRegisterCandidate(
+            new VoteTestContext(neoSystem, wallet),
+            account: account.ScriptHash,
+            relayAnswer: "no");
+
+        Assert.Contains("Registering candidate via GAS transfer to NEO contract", output);
+        Assert.DoesNotContain("Invoking script with:", output);
+    }
+
+    private static string RunRegisterCandidate(VoteTestContext context, UInt160? account = null, string? relayAnswer = null)
+    {
+        account ??= context.Wallet?.CreateAccount().ScriptHash ?? UInt160.Zero;
+
+        return InvokeWithConsoleCapture(context, service =>
+            InvokeNonPublic(service, "OnRegisterCandidateCommand", account), relayAnswer);
+    }
+
+    private static string RunRegisterCandidateViaNep17Payment(
+        VoteTestContext context,
+        UInt160 account,
+        ECPoint publicKey,
+        DataCache snapshot,
+        string? relayAnswer)
+    {
+        return InvokeWithConsoleCapture(context, service =>
+            InvokeNonPublic(service, "RegisterCandidateViaNep17Payment", account, publicKey, snapshot), relayAnswer);
+    }
+
+    private static string InvokeWithConsoleCapture(VoteTestContext context, Action<MainService> invoke, string? relayAnswer)
+    {
+        var service = CreateService(context);
+
+        var outputWriter = new StringWriter();
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        var originalIn = Console.In;
+
+        Console.SetOut(outputWriter);
+        Console.SetError(outputWriter);
+        if (relayAnswer != null)
+            Console.SetIn(new StringReader(relayAnswer + Environment.NewLine));
+
+        try
+        {
+            invoke(service);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+            Console.SetIn(originalIn);
+        }
+
+        return outputWriter.ToString();
+    }
+
+    private static MainService CreateService(VoteTestContext context)
+    {
+        var service = new MainService();
+        TrySet(service, "NeoSystem", context.NeoSystem);
+        TrySetField(service, "_neoSystem", context.NeoSystem);
+
+        if (context.Wallet != null)
+        {
+            TrySet(service, "CurrentWallet", context.Wallet);
+            TrySetField(service, "_currentWallet", context.Wallet);
+        }
+
+        return service;
+    }
+
+    private static void FundGas(NeoSystem neoSystem, UInt160 account, BigInteger balance)
+    {
+        var key = new KeyBuilder(NativeContract.GAS.Id, 20).Add(account);
+        var snapshot = neoSystem.GetSnapshotCache();
+        var entry = snapshot.GetAndChange(key, () => new StorageItem(new AccountState()));
+        entry.GetInteroperable<AccountState>().Balance = balance;
+        snapshot.Commit();
+    }
+
+    private static void TrySet(object target, string propertyName, object value)
+    {
+        var prop = target.GetType().GetProperty(
+            propertyName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        prop?.SetValue(target, value);
+    }
+
+    private static void TrySetField(object target, string fieldName, object value)
+    {
+        var field = target.GetType().GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        field?.SetValue(target, value);
+    }
+
+    private static object InvokeNonPublic(object target, string methodName, params object[] args)
+    {
+        var method = target.GetType().GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(method, $"Method '{methodName}' not found on type '{target.GetType().FullName}'.");
+        return method!.Invoke(target, args)!;
+    }
+
+    private sealed record VoteTestContext(NeoSystem NeoSystem, Wallet? Wallet = null);
+}

--- a/tests/Neo.CLI.Tests/UT_MainService_Vote.cs
+++ b/tests/Neo.CLI.Tests/UT_MainService_Vote.cs
@@ -17,7 +17,6 @@ using Neo.SmartContract;
 using Neo.SmartContract.Native;
 using Neo.Wallets;
 using System.Numerics;
-using System.Reflection;
 using System.Security.Cryptography;
 using ECPoint = Neo.Cryptography.ECC.ECPoint;
 
@@ -287,7 +286,7 @@ public class UT_MainService_Vote
         account ??= context.Wallet?.CreateAccount().ScriptHash ?? UInt160.Zero;
 
         return InvokeWithConsoleCapture(context, service =>
-            InvokeNonPublic(service, "OnRegisterCandidateCommand", account), relayAnswer);
+            TestUtils.InvokeNonPublic(service, "OnRegisterCandidateCommand", account), relayAnswer);
     }
 
     private static string RunRegisterCandidateViaNep17Payment(
@@ -298,7 +297,7 @@ public class UT_MainService_Vote
         string? relayAnswer)
     {
         return InvokeWithConsoleCapture(context, service =>
-            InvokeNonPublic(service, "RegisterCandidateViaNep17Payment", account, publicKey, snapshot), relayAnswer);
+            TestUtils.InvokeNonPublic(service, "RegisterCandidateViaNep17Payment", account, publicKey, snapshot), relayAnswer);
     }
 
     private static string InvokeWithConsoleCapture(VoteTestContext context, Action<MainService> invoke, string? relayAnswer)
@@ -332,13 +331,13 @@ public class UT_MainService_Vote
     private static MainService CreateService(VoteTestContext context)
     {
         var service = new MainService();
-        TrySet(service, "NeoSystem", context.NeoSystem);
-        TrySetField(service, "_neoSystem", context.NeoSystem);
+        TestUtils.TrySet(service, "NeoSystem", context.NeoSystem);
+        TestUtils.TrySetField(service, "_neoSystem", context.NeoSystem);
 
         if (context.Wallet != null)
         {
-            TrySet(service, "CurrentWallet", context.Wallet);
-            TrySetField(service, "_currentWallet", context.Wallet);
+            TestUtils.TrySet(service, "CurrentWallet", context.Wallet);
+            TestUtils.TrySetField(service, "_currentWallet", context.Wallet);
         }
 
         return service;
@@ -351,31 +350,6 @@ public class UT_MainService_Vote
         var entry = snapshot.GetAndChange(key, () => new StorageItem(new AccountState()));
         entry.GetInteroperable<AccountState>().Balance = balance;
         snapshot.Commit();
-    }
-
-    private static void TrySet(object target, string propertyName, object value)
-    {
-        var prop = target.GetType().GetProperty(
-            propertyName,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-        prop?.SetValue(target, value);
-    }
-
-    private static void TrySetField(object target, string fieldName, object value)
-    {
-        var field = target.GetType().GetField(
-            fieldName,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-        field?.SetValue(target, value);
-    }
-
-    private static object InvokeNonPublic(object target, string methodName, params object[] args)
-    {
-        var method = target.GetType().GetMethod(
-            methodName,
-            BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.IsNotNull(method, $"Method '{methodName}' not found on type '{target.GetType().FullName}'.");
-        return method!.Invoke(target, args)!;
     }
 
     private sealed record VoteTestContext(NeoSystem NeoSystem, Wallet? Wallet = null);

--- a/tests/Neo.CLI.Tests/UT_MainService_Wallet.cs
+++ b/tests/Neo.CLI.Tests/UT_MainService_Wallet.cs
@@ -346,8 +346,8 @@ public class UT_MainService_Wallet
     {
         var service = new MainService();
 
-        TrySet(service, "NeoSystem", _neoSystem);
-        TrySetField(service, "_neoSystem", _neoSystem);
+        TestUtils.TrySet(service, "NeoSystem", _neoSystem);
+        TestUtils.TrySetField(service, "_neoSystem", _neoSystem);
 
         var originalOut = Console.Out;
         var originalErr = Console.Error;
@@ -358,7 +358,7 @@ public class UT_MainService_Wallet
 
         try
         {
-            InvokeNonPublic(service, "OnVerifyMessageCommand", message, signature, publicKey, salt, avoidSignatureReplay);
+            TestUtils.InvokeNonPublic(service, "OnVerifyMessageCommand", message, signature, publicKey, salt, avoidSignatureReplay);
         }
         finally
         {
@@ -383,10 +383,10 @@ public class UT_MainService_Wallet
 
         var service = new MainService();
 
-        TrySet(service, "NeoSystem", _neoSystem);
-        TrySetField(service, "_neoSystem", _neoSystem);
-        TrySet(service, "CurrentWallet", wallet);
-        TrySetField(service, "_currentWallet", wallet);
+        TestUtils.TrySet(service, "NeoSystem", _neoSystem);
+        TestUtils.TrySetField(service, "_neoSystem", _neoSystem);
+        TestUtils.TrySet(service, "CurrentWallet", wallet);
+        TestUtils.TrySetField(service, "_currentWallet", wallet);
 
         var readInputProp = service.GetType().GetProperty(
             "ReadUserInput",
@@ -409,7 +409,7 @@ public class UT_MainService_Wallet
 
         try
         {
-            InvokeNonPublic(service, "OnSignMessageCommand", message, addSignData);
+            TestUtils.InvokeNonPublic(service, "OnSignMessageCommand", message, addSignData);
         }
         finally
         {
@@ -431,10 +431,10 @@ public class UT_MainService_Wallet
 
         var service = new MainService();
 
-        TrySet(service, "NeoSystem", _neoSystem);
-        TrySetField(service, "_neoSystem", _neoSystem);
-        TrySet(service, "CurrentWallet", wallet);
-        TrySetField(service, "_currentWallet", wallet);
+        TestUtils.TrySet(service, "NeoSystem", _neoSystem);
+        TestUtils.TrySetField(service, "_neoSystem", _neoSystem);
+        TestUtils.TrySet(service, "CurrentWallet", wallet);
+        TestUtils.TrySetField(service, "_currentWallet", wallet);
 
         var readInputProp = service.GetType().GetProperty(
             "ReadUserInput",
@@ -456,7 +456,7 @@ public class UT_MainService_Wallet
 
         try
         {
-            var result = (bool)InvokeNonPublic(service, "OnCommand", command);
+            var result = (bool)TestUtils.InvokeNonPublic(service, "OnCommand", command)!;
             Assert.IsTrue(result, "Command should be handled");
         }
         finally
@@ -491,10 +491,10 @@ public class UT_MainService_Wallet
 
         var service = new MainService();
 
-        TrySet(service, "NeoSystem", _neoSystem);
-        TrySetField(service, "_neoSystem", _neoSystem);
-        TrySet(service, "CurrentWallet", wallet);
-        TrySetField(service, "_currentWallet", wallet);
+        TestUtils.TrySet(service, "NeoSystem", _neoSystem);
+        TestUtils.TrySetField(service, "_neoSystem", _neoSystem);
+        TestUtils.TrySet(service, "CurrentWallet", wallet);
+        TestUtils.TrySetField(service, "_currentWallet", wallet);
 
         var originalOut = Console.Out;
         var originalErr = Console.Error;
@@ -504,7 +504,7 @@ public class UT_MainService_Wallet
 
         try
         {
-            InvokeNonPublic(service, "OnSignCommand", jsonObjectToSign);
+            TestUtils.InvokeNonPublic(service, "OnSignCommand", jsonObjectToSign);
         }
         finally
         {
@@ -543,37 +543,6 @@ public class UT_MainService_Wallet
         }
 
         return true;
-    }
-
-    private static void TrySet(object target, string propertyName, object value)
-    {
-        var prop = target.GetType().GetProperty(
-            propertyName,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
-        );
-
-        prop?.SetValue(target, value);
-    }
-
-    private static void TrySetField(object target, string fieldName, object value)
-    {
-        var field = target.GetType().GetField(
-            fieldName,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
-        );
-
-        field?.SetValue(target, value);
-    }
-
-    private static object InvokeNonPublic(object target, string methodName, params object[] args)
-    {
-        var method = target.GetType().GetMethod(
-            methodName,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
-        );
-
-        Assert.IsNotNull(method, $"Method '{methodName}' not found on type '{target.GetType().FullName}'.");
-        return method.Invoke(target, args);
     }
 
     private static string ExtractMessageFromSignedPayload(string payloadHex)


### PR DESCRIPTION
Now `MaxBlockSystemFee` in `DBFTPlugin` is 20 GAS, original register candidate method can't handle anymore with so little systemfee. Now change that way to invoke `OnNEP17Payment` of Neo native contract.