### PR TITLE
Strengthen RPC server defaults

### DIFF
--- a/plugins/RpcServer/RcpServerSettings.cs
+++ b/plugins/RpcServer/RcpServerSettings.cs
@@ -37,7 +37,7 @@ public record RpcServersSettings
     public string SslCertPassword { get; init; } = string.Empty;
     public string[] TrustedAuthorities { get; init; } = [];
     public int MaxConcurrentConnections { get; init; } = 40;
-    public int MaxRequestBodySize { get; init; } = 5 * 1024 * 1024;
+    public int MaxRequestBodySize { get; init; } = 1 * 1024 * 1024;
     public string RpcUser { get; init; } = string.Empty;
     public string RpcPass { get; init; } = string.Empty;
     public bool EnableCors { get; init; } = true;

--- a/plugins/RpcServer/RpcServer.Node.cs
+++ b/plugins/RpcServer/RpcServer.Node.cs
@@ -210,7 +210,7 @@ partial class RpcServer
     {
         var txData = Result.Ok_Or(
             () => Convert.FromBase64String(base64Tx),
-            throw new RpcException(RpcError.InvalidParams.WithData("Invalid Transaction Format: Expected Base64-encoded string"));
+            RpcError.InvalidParams.WithData("Invalid Transaction Format: Expected Base64-encoded string"));
 
         if (txData.Length > Transaction.MaxTransactionSize)
             throw new RpcException(RpcError.InvalidParams.WithData("Transaction size exceeds the maximum allowed."));

--- a/plugins/RpcServer/RpcServer.Node.cs
+++ b/plugins/RpcServer/RpcServer.Node.cs
@@ -213,7 +213,7 @@ partial class RpcServer
             throw new RpcException(RpcError.InvalidParams.WithData("Invalid Transaction Format: Expected Base64-encoded string"));
 
         if (txData.Length > Transaction.MaxTransactionSize)
-            RpcError.InvalidParams.WithData("Transaction size exceeds the maximum allowed.");
+            throw new RpcException(RpcError.InvalidParams.WithData("Transaction size exceeds the maximum allowed."));
 
         var tx = Result.Ok_Or(
             () => txData.AsSerializable<Transaction>(),

--- a/plugins/RpcServer/RpcServer.Node.cs
+++ b/plugins/RpcServer/RpcServer.Node.cs
@@ -208,9 +208,17 @@ partial class RpcServer
     [RpcMethod]
     protected internal virtual JToken SendRawTransaction(string base64Tx)
     {
+        var txData = Result.Ok_Or(
+            () => Convert.FromBase64String(base64Tx),
+            RpcError.InvalidParams.WithData($"Invalid Transaction Format: Expected Base64-encoded string"));
+
+        if (txData.Length > Transaction.MaxTransactionSize)
+            RpcError.InvalidParams.WithData("Transaction size exceeds the maximum allowed.");
+
         var tx = Result.Ok_Or(
-            () => Convert.FromBase64String(base64Tx).AsSerializable<Transaction>(),
-            RpcError.InvalidParams.WithData($"Invalid Transaction Format: {base64Tx}"));
+            () => txData.AsSerializable<Transaction>(),
+            RpcError.InvalidParams.WithData("Invalid Transaction Format"));
+
         var relayResult = system.Blockchain.Ask<RelayResult>(tx, TimeSpan.FromSeconds(30)).Result;
         return GetRelayResult(relayResult.Result, tx.Hash);
     }

--- a/plugins/RpcServer/RpcServer.Node.cs
+++ b/plugins/RpcServer/RpcServer.Node.cs
@@ -210,7 +210,7 @@ partial class RpcServer
     {
         var txData = Result.Ok_Or(
             () => Convert.FromBase64String(base64Tx),
-            RpcError.InvalidParams.WithData($"Invalid Transaction Format: Expected Base64-encoded string"));
+            throw new RpcException(RpcError.InvalidParams.WithData("Invalid Transaction Format: Expected Base64-encoded string"));
 
         if (txData.Length > Transaction.MaxTransactionSize)
             RpcError.InvalidParams.WithData("Transaction size exceeds the maximum allowed.");

--- a/plugins/RpcServer/RpcServer.cs
+++ b/plugins/RpcServer/RpcServer.cs
@@ -155,7 +155,7 @@ public partial class RpcServer : IDisposable
         {
             builder.UseKestrel(options => options.Listen(settings.BindAddress, settings.Port, listenOptions =>
             {
-                // Default value is 5Mb
+                // Default value is 1Mb
                 options.Limits.MaxRequestBodySize = settings.MaxRequestBodySize;
                 options.Limits.MaxRequestLineSize = Math.Min(settings.MaxRequestBodySize, options.Limits.MaxRequestLineSize);
                 // Default value is 40

--- a/plugins/RpcServer/RpcServer.json
+++ b/plugins/RpcServer/RpcServer.json
@@ -17,6 +17,7 @@
         "RequestHeadersTimeout": 15,
         "MaxGasInvoke": 20,
         "MaxFee": 0.1,
+        "MaxRequestBodySize": 1048576,
         "MaxConcurrentConnections": 40,
         "MaxIteratorResultItems": 100,
         "MaxStackSize": 65535,

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.cs
@@ -429,7 +429,7 @@ public partial class UT_RpcServer
         Assert.HasCount(1, settings.DisabledMethods);
         Assert.AreEqual("openwallet", settings.DisabledMethods[0]);
         Assert.AreEqual(40, settings.MaxConcurrentConnections);
-        Assert.AreEqual(5 * 1024 * 1024, settings.MaxRequestBodySize);
+        Assert.AreEqual(1 * 1024 * 1024, settings.MaxRequestBodySize);
         Assert.AreEqual(50, settings.FindStoragePageSize);
     }
 


### PR DESCRIPTION
- Reduce default `MaxRequestBodySize` from 5mb to 1mb.
- Set `MaxRequestBodySize` in json file to help with configuration.
- Prevent Transaction deserialization if it's bigger than expected.