### PR TITLE
Improve DeferredRelay

### DIFF
--- a/plugins/DeferredRelay/DeferredQueueContext.cs
+++ b/plugins/DeferredRelay/DeferredQueueContext.cs
@@ -1,0 +1,102 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// DeferredQueueContext.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Extensions;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+
+namespace Neo.Plugins.DeferredRelay;
+
+/// <summary>
+/// Tracks per-sender queue depth and builds a <see cref="TransactionVerificationContext"/> that
+/// includes already-queued transactions (fee/oracle aggregation for deferred offers).
+/// </summary>
+internal sealed class DeferredQueueContext
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<UInt160, int> _senderCounts = new();
+    private readonly List<Transaction> _queued = new();
+
+    public static DeferredQueueContext Bootstrap(IStore store)
+    {
+        var context = new DeferredQueueContext();
+        foreach ((byte[] key, byte[] value) in store.Find())
+        {
+            if (key.Length != UInt256.Length) continue;
+            try
+            {
+                context.OnQueued(value.AsSerializable<Transaction>());
+            }
+            catch
+            {
+                // Corrupt entries are ignored here; ProcessQueuedAsync removes them later.
+            }
+        }
+
+        return context;
+    }
+
+    public bool CanAcceptSender(UInt160 sender, uint maxPerSender)
+    {
+        if (maxPerSender == 0) return true;
+        lock (_lock)
+        {
+            _senderCounts.TryGetValue(sender, out int count);
+            return count < maxPerSender;
+        }
+    }
+
+    public TransactionVerificationContext CreateVerificationContext()
+    {
+        var context = new TransactionVerificationContext();
+        lock (_lock)
+        {
+            foreach (Transaction tx in _queued)
+                context.AddTransaction(tx);
+        }
+
+        return context;
+    }
+
+    public void OnQueued(Transaction tx)
+    {
+        lock (_lock)
+        {
+            _queued.Add(tx);
+            _senderCounts.TryGetValue(tx.Sender, out int count);
+            _senderCounts[tx.Sender] = count + 1;
+        }
+    }
+
+    public void OnRemoved(Transaction tx)
+    {
+        lock (_lock)
+        {
+            for (int i = _queued.Count - 1; i >= 0; i--)
+            {
+                if (_queued[i].Hash == tx.Hash)
+                {
+                    _queued.RemoveAt(i);
+                    break;
+                }
+            }
+
+            if (_senderCounts.TryGetValue(tx.Sender, out int count))
+            {
+                if (count <= 1)
+                    _senderCounts.Remove(tx.Sender);
+                else
+                    _senderCounts[tx.Sender] = count - 1;
+            }
+        }
+    }
+}

--- a/plugins/DeferredRelay/DeferredQueueContext.cs
+++ b/plugins/DeferredRelay/DeferredQueueContext.cs
@@ -24,7 +24,7 @@ internal sealed class DeferredQueueContext
 {
     private readonly Lock _lock = new();
     private readonly Dictionary<UInt160, int> _senderCounts = new();
-    private readonly List<Transaction> _queued = new();
+    private readonly Dictionary<UInt256, Transaction> _queued = new();
 
     public static DeferredQueueContext Bootstrap(IStore store)
     {
@@ -60,7 +60,7 @@ internal sealed class DeferredQueueContext
         var context = new TransactionVerificationContext();
         lock (_lock)
         {
-            foreach (Transaction tx in _queued)
+            foreach (Transaction tx in _queued.Values)
                 context.AddTransaction(tx);
         }
 
@@ -71,7 +71,7 @@ internal sealed class DeferredQueueContext
     {
         lock (_lock)
         {
-            _queued.Add(tx);
+            _queued[tx.Hash] = tx;
             _senderCounts.TryGetValue(tx.Sender, out int count);
             _senderCounts[tx.Sender] = count + 1;
         }
@@ -81,14 +81,7 @@ internal sealed class DeferredQueueContext
     {
         lock (_lock)
         {
-            for (int i = _queued.Count - 1; i >= 0; i--)
-            {
-                if (_queued[i].Hash == tx.Hash)
-                {
-                    _queued.RemoveAt(i);
-                    break;
-                }
-            }
+            _queued.Remove(tx.Hash);
 
             if (_senderCounts.TryGetValue(tx.Sender, out int count))
             {

--- a/plugins/DeferredRelay/DeferredQueueContext.cs
+++ b/plugins/DeferredRelay/DeferredQueueContext.cs
@@ -22,7 +22,7 @@ namespace Neo.Plugins.DeferredRelay;
 /// </summary>
 internal sealed class DeferredQueueContext
 {
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
     private readonly Dictionary<UInt160, int> _senderCounts = new();
     private readonly List<Transaction> _queued = new();
 

--- a/plugins/DeferredRelay/DeferredRelay.json
+++ b/plugins/DeferredRelay/DeferredRelay.json
@@ -2,6 +2,8 @@
   "PluginConfiguration": {
     "Path": "DeferredRelay_{0}",
     "MaxTransactions": 0,
+    "MaxTransactionsPerSender": 0,
+    "MinNetworkFee": 0,
     "CheckFrequency": 0,
     "UnhandledExceptionPolicy": "StopPlugin"
   },

--- a/plugins/DeferredRelay/DeferredRelayActor.cs
+++ b/plugins/DeferredRelay/DeferredRelayActor.cs
@@ -27,15 +27,21 @@ internal sealed class DeferredRelayActor : UntypedActor
     private readonly DeferredQueueContext _queueContext;
     private bool _processingQueued;
 
-    public DeferredRelayActor(NeoSystem neo, IStore store, DeferredRelaySettings settings)
+    public DeferredRelayActor(NeoSystem neo, IStore store, DeferredRelaySettings settings,
+        EntryCounter? counter = null, DeferredQueueContext? queueContext = null)
     {
         _neo = neo;
         _store = store;
         _settings = settings;
-        // Bootstrap once at startup; afterwards the counter is maintained incrementally
-        // by TryOffer (++) and ProcessQueuedAsync (--), so the per-offer capacity check is O(1).
-        _counter = new EntryCounter(DeferredRelayEngine.CountEntries(store));
-        _queueContext = DeferredQueueContext.Bootstrap(store);
+        if (counter is null || queueContext is null)
+        {
+            var state = DeferredRelayEngine.CreateQueueState(neo, store, settings);
+            counter ??= state.Counter;
+            queueContext ??= state.Context;
+        }
+
+        _counter = counter;
+        _queueContext = queueContext;
     }
 
     protected override void PreStart()

--- a/plugins/DeferredRelay/DeferredRelayActor.cs
+++ b/plugins/DeferredRelay/DeferredRelayActor.cs
@@ -24,6 +24,7 @@ internal sealed class DeferredRelayActor : UntypedActor
     private readonly IStore _store;
     private readonly DeferredRelaySettings _settings;
     private readonly EntryCounter _counter;
+    private readonly DeferredQueueContext _queueContext;
     private bool _processingQueued;
 
     public DeferredRelayActor(NeoSystem neo, IStore store, DeferredRelaySettings settings)
@@ -34,6 +35,7 @@ internal sealed class DeferredRelayActor : UntypedActor
         // Bootstrap once at startup; afterwards the counter is maintained incrementally
         // by TryOffer (++) and ProcessQueuedAsync (--), so the per-offer capacity check is O(1).
         _counter = new EntryCounter(DeferredRelayEngine.CountEntries(store));
+        _queueContext = DeferredQueueContext.Bootstrap(store);
     }
 
     protected override void PreStart()
@@ -50,7 +52,7 @@ internal sealed class DeferredRelayActor : UntypedActor
         switch (message)
         {
             case Blockchain.RelayResult { Inventory: Transaction tx, Result: VerifyResult.NotYetValid } rr:
-                DeferredRelayEngine.TryOffer(_neo, _store, _settings, tx, rr.Result, _counter);
+                DeferredRelayEngine.TryOffer(_neo, _store, _settings, tx, rr.Result, _counter, _queueContext);
                 break;
             case Blockchain.PersistCompleted pc:
                 ScheduleProcessQueued(pc.Block);
@@ -72,7 +74,7 @@ internal sealed class DeferredRelayActor : UntypedActor
 
         _processingQueued = true;
         var self = Self;
-        _ = DeferredRelayEngine.ProcessQueuedAsync(_neo, _store, _settings, counter: _counter)
+        _ = DeferredRelayEngine.ProcessQueuedAsync(_neo, _store, _settings, counter: _counter, queueContext: _queueContext)
             .ContinueWith(t =>
             {
                 if (t.IsFaulted)

--- a/plugins/DeferredRelay/DeferredRelayEngine.cs
+++ b/plugins/DeferredRelay/DeferredRelayEngine.cs
@@ -103,6 +103,10 @@ internal static class DeferredRelayEngine
         if (store.Contains(key))
             return true;
 
+        // Fallback callers (no in-memory counter): compact before counting store entries.
+        if (counter is null)
+            queueContext ??= BootstrapQueueContext(system, store, settings);
+
         int currentCount = counter?.Value ?? CountEntries(store);
         if (currentCount >= settings.MaxTransactions)
             return false;
@@ -171,7 +175,7 @@ internal static class DeferredRelayEngine
         var snapshot = system.StoreView;
         uint height = NativeContract.Ledger.CurrentIndex(snapshot);
         uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(system.Settings);
-        ClassifyQueueEntries(system, store, settings, out List<byte[]> toRemove, out List<Transaction> survivors);
+        ClassifyQueueEntries(system, store, settings, out List<byte[]> toRemove, out List<Transaction> survivors, cancellationToken);
 
         List<Transaction> toRelay = [];
         foreach (Transaction tx in survivors)
@@ -269,7 +273,8 @@ internal static class DeferredRelayEngine
         IStore store,
         DeferredRelaySettings settings,
         out List<byte[]> toRemove,
-        out List<Transaction> survivors)
+        out List<Transaction> survivors,
+        CancellationToken cancellationToken = default)
     {
         toRemove = [];
         survivors = [];
@@ -282,6 +287,7 @@ internal static class DeferredRelayEngine
 
         foreach ((byte[] key, byte[] value) in store.Find())
         {
+            cancellationToken.ThrowIfCancellationRequested();
             // Schema guard: only 32-byte (UInt256) keys are transaction entries; see CountEntries.
             if (key.Length != UInt256.Length) continue;
 
@@ -314,6 +320,7 @@ internal static class DeferredRelayEngine
         var verifyContext = new TransactionVerificationContext();
         foreach ((byte[] key, Transaction tx) in candidates)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (DeferredRelayVerification.VerifyForOffer(system.Settings, snapshot, tx, verifyContext) != VerifyResult.Succeed)
                 toRemove.Add(key);
             else

--- a/plugins/DeferredRelay/DeferredRelayEngine.cs
+++ b/plugins/DeferredRelay/DeferredRelayEngine.cs
@@ -84,7 +84,11 @@ internal static class DeferredRelayEngine
     /// instead of scanning the store, and the counter is incremented on a successful <c>Put</c>.
     /// Callers that do not maintain a counter (e.g. tests) pass <c>null</c>, falling back to <see cref="CountEntries"/>.
     /// </param>
-    public static bool TryOffer(NeoSystem system, IStore store, DeferredRelaySettings settings, Transaction tx, VerifyResult relayResult, EntryCounter? counter = null)
+    /// <param name="queueContext">
+    /// Optional in-memory deferred-queue state (per-sender limits and fee aggregation).
+    /// When <c>null</c>, a fresh context is bootstrapped from <paramref name="store"/> on each call.
+    /// </param>
+    public static bool TryOffer(NeoSystem system, IStore store, DeferredRelaySettings settings, Transaction tx, VerifyResult relayResult, EntryCounter? counter = null, DeferredQueueContext? queueContext = null)
     {
         if (!settings.Enabled)
             return false;
@@ -103,8 +107,21 @@ internal static class DeferredRelayEngine
         if (currentCount >= settings.MaxTransactions)
             return false;
 
+        if (settings.MinNetworkFee > 0 && tx.NetworkFee < settings.MinNetworkFee)
+            return false;
+
+        queueContext ??= DeferredQueueContext.Bootstrap(store);
+        if (!queueContext.CanAcceptSender(tx.Sender, settings.MaxTransactionsPerSender))
+            return false;
+
+        var snapshot = system.StoreView;
+        var verifyContext = queueContext.CreateVerificationContext();
+        if (DeferredRelayVerification.VerifyForOffer(system.Settings, snapshot, tx, verifyContext) != VerifyResult.Succeed)
+            return false;
+
         store.Put(key, tx.ToArray());
         counter?.Increment();
+        queueContext.OnQueued(tx);
         return true;
     }
 
@@ -146,7 +163,7 @@ internal static class DeferredRelayEngine
     /// Optional in-memory entry counter; decremented on every successful <c>Delete</c> so that
     /// <see cref="TryOffer"/> can perform its capacity check without re-scanning the store.
     /// </param>
-    public static async Task ProcessQueuedAsync(NeoSystem system, IStore store, DeferredRelaySettings settings, EntryCounter? counter = null, CancellationToken cancellationToken = default)
+    public static async Task ProcessQueuedAsync(NeoSystem system, IStore store, DeferredRelaySettings settings, EntryCounter? counter = null, DeferredQueueContext? queueContext = null, CancellationToken cancellationToken = default)
     {
         var snapshot = system.StoreView;
         uint height = NativeContract.Ledger.CurrentIndex(snapshot);
@@ -182,8 +199,22 @@ internal static class DeferredRelayEngine
                 toRelay.Add(tx);
         }
 
+        queueContext ??= DeferredQueueContext.Bootstrap(store);
+
         foreach (byte[] key in toRemove)
         {
+            if (store.TryGet(key, out byte[]? value))
+            {
+                try
+                {
+                    queueContext.OnRemoved(value.AsSerializable<Transaction>());
+                }
+                catch
+                {
+                    // Corrupt entries have no queue-context state to reconcile.
+                }
+            }
+
             store.Delete(key);
             counter?.Decrement();
         }
@@ -198,26 +229,38 @@ internal static class DeferredRelayEngine
             // and every Ask -- whether it eventually returns Succeed, AlreadyInPool, or a failure --
             // already occupies one slot in that mailbox.
             attempts++;
-            if (!await TryRelayAsync(system, tx).ConfigureAwait(false))
+            var relayOutcome = await TryRelayAsync(system, tx).ConfigureAwait(false);
+            if (relayOutcome is VerifyResult.Succeed or VerifyResult.AlreadyInPool or VerifyResult.AlreadyExists)
+            {
+                RemoveQueued(store, tx, counter, queueContext);
                 continue;
-            store.Delete(tx.Hash.GetSpan().ToArray());
-            counter?.Decrement();
+            }
+
+            if (DeferredRelayVerification.IsDefinitiveRelayFailure(relayOutcome))
+                RemoveQueued(store, tx, counter, queueContext);
         }
     }
 
-    private static async Task<bool> TryRelayAsync(NeoSystem system, Transaction tx)
+    private static void RemoveQueued(IStore store, Transaction tx, EntryCounter? counter, DeferredQueueContext queueContext)
+    {
+        store.Delete(tx.Hash.GetSpan().ToArray());
+        counter?.Decrement();
+        queueContext.OnRemoved(tx);
+    }
+
+    private static async Task<VerifyResult> TryRelayAsync(NeoSystem system, Transaction tx)
     {
         try
         {
             var relayResult = await system.Blockchain
                 .Ask<Blockchain.RelayResult>(tx, TimeSpan.FromSeconds(30))
                 .ConfigureAwait(false);
-            return relayResult.Result is VerifyResult.Succeed or VerifyResult.AlreadyInPool or VerifyResult.AlreadyExists;
+            return relayResult.Result;
         }
         catch (Exception ex)
         {
             Logs.RuntimeLogger.Debug(ex, "Deferred relay attempt failed for {Hash}", tx.Hash);
-            return false;
+            return VerifyResult.Unknown;
         }
     }
 

--- a/plugins/DeferredRelay/DeferredRelayEngine.cs
+++ b/plugins/DeferredRelay/DeferredRelayEngine.cs
@@ -110,7 +110,7 @@ internal static class DeferredRelayEngine
         if (settings.MinNetworkFee > 0 && tx.NetworkFee < settings.MinNetworkFee)
             return false;
 
-        queueContext ??= DeferredQueueContext.Bootstrap(store);
+        queueContext ??= BootstrapQueueContext(system, store, settings);
         if (!queueContext.CanAcceptSender(tx.Sender, settings.MaxTransactionsPerSender))
             return false;
 
@@ -154,7 +154,8 @@ internal static class DeferredRelayEngine
     }
 
     /// <summary>
-    /// Scans the local queue, removes expired or corrupt entries, and relays txs that entered the allowed window.
+    /// Scans the local queue, removes expired, corrupt, or state-dependent-invalid entries, and relays txs
+    /// that entered the allowed window.
     /// The number of relay attempts is capped at <see cref="DeferredRelaySettings.MaxRelayPerCycle"/> so a single
     /// drain pass cannot monopolize the Blockchain actor mailbox when the queue is near capacity; the unrelayed
     /// remainder stays in the store and is picked up by the next <see cref="ShouldProcessPersist"/>-eligible block.
@@ -165,37 +166,17 @@ internal static class DeferredRelayEngine
     /// </param>
     public static async Task ProcessQueuedAsync(NeoSystem system, IStore store, DeferredRelaySettings settings, EntryCounter? counter = null, DeferredQueueContext? queueContext = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var snapshot = system.StoreView;
         uint height = NativeContract.Ledger.CurrentIndex(snapshot);
         uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(system.Settings);
-        List<byte[]> toRemove = [];
+        ClassifyQueueEntries(system, store, settings, out List<byte[]> toRemove, out List<Transaction> survivors);
+
         List<Transaction> toRelay = [];
-
-        foreach ((byte[] key, byte[] value) in store.Find())
+        foreach (Transaction tx in survivors)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            // Schema guard: only 32-byte (UInt256) keys are transaction entries; see CountEntries.
-            // Non-tx entries are left untouched (not added to toRemove) to keep future metadata safe.
-            if (key.Length != UInt256.Length) continue;
-
-            Transaction tx;
-            try
-            {
-                tx = value.AsSerializable<Transaction>();
-            }
-            catch
-            {
-                toRemove.Add(key);
-                continue;
-            }
-
-            if (height >= tx.ValidUntilBlock)
-            {
-                toRemove.Add(key);
-                continue;
-            }
-
-            if (height < tx.ValidUntilBlock && tx.ValidUntilBlock <= height + maxInc)
+            if (tx.ValidUntilBlock <= height + maxInc)
                 toRelay.Add(tx);
         }
 
@@ -262,6 +243,101 @@ internal static class DeferredRelayEngine
             Logs.RuntimeLogger.Debug(ex, "Deferred relay attempt failed for {Hash}", tx.Hash);
             return VerifyResult.Unknown;
         }
+    }
+
+    /// <summary>
+    /// Drops expired, corrupt, and state-dependent-invalid entries from the local store before
+    /// rebuilding in-memory queue state. Called on actor/plugin startup so <see cref="DeferredQueueContext.Bootstrap"/>
+    /// does not retain stale txs that would occupy per-sender slots or skew fee aggregation.
+    /// The same classification runs on every <see cref="ProcessQueuedAsync"/> cycle while the node is online.
+    /// </summary>
+    internal static void CompactStore(NeoSystem system, IStore store, DeferredRelaySettings settings)
+    {
+        if (!settings.Enabled)
+            return;
+
+        ClassifyQueueEntries(system, store, settings, out List<byte[]> toRemove, out _);
+        foreach (byte[] key in toRemove)
+            store.Delete(key);
+    }
+
+    /// <summary>
+    /// Returns store keys to evict and surviving transactions (stable store order, fee-aggregation aware).
+    /// </summary>
+    private static void ClassifyQueueEntries(
+        NeoSystem system,
+        IStore store,
+        DeferredRelaySettings settings,
+        out List<byte[]> toRemove,
+        out List<Transaction> survivors)
+    {
+        toRemove = [];
+        survivors = [];
+        if (!settings.Enabled)
+            return;
+
+        var snapshot = system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        List<(byte[] Key, Transaction Tx)> candidates = [];
+
+        foreach ((byte[] key, byte[] value) in store.Find())
+        {
+            // Schema guard: only 32-byte (UInt256) keys are transaction entries; see CountEntries.
+            if (key.Length != UInt256.Length) continue;
+
+            Transaction tx;
+            try
+            {
+                tx = value.AsSerializable<Transaction>();
+            }
+            catch
+            {
+                toRemove.Add(key);
+                continue;
+            }
+
+            if (height >= tx.ValidUntilBlock)
+            {
+                toRemove.Add(key);
+                continue;
+            }
+
+            if (settings.MinNetworkFee > 0 && tx.NetworkFee < settings.MinNetworkFee)
+            {
+                toRemove.Add(key);
+                continue;
+            }
+
+            candidates.Add((key, tx));
+        }
+
+        var verifyContext = new TransactionVerificationContext();
+        foreach ((byte[] key, Transaction tx) in candidates)
+        {
+            if (DeferredRelayVerification.VerifyForOffer(system.Settings, snapshot, tx, verifyContext) != VerifyResult.Succeed)
+                toRemove.Add(key);
+            else
+            {
+                verifyContext.AddTransaction(tx);
+                survivors.Add(tx);
+            }
+        }
+    }
+
+    internal static DeferredQueueContext BootstrapQueueContext(NeoSystem system, IStore store, DeferredRelaySettings settings)
+    {
+        CompactStore(system, store, settings);
+        return DeferredQueueContext.Bootstrap(store);
+    }
+
+    /// <summary>
+    /// Compacts the store and builds the in-memory counter/context pair used by <see cref="DeferredRelayActor"/>.
+    /// </summary>
+    internal static (EntryCounter Counter, DeferredQueueContext Context) CreateQueueState(
+        NeoSystem system, IStore store, DeferredRelaySettings settings)
+    {
+        var context = BootstrapQueueContext(system, store, settings);
+        return (new EntryCounter(CountEntries(store)), context);
     }
 
     /// <summary>

--- a/plugins/DeferredRelay/DeferredRelayPlugin.cs
+++ b/plugins/DeferredRelay/DeferredRelayPlugin.cs
@@ -53,8 +53,9 @@ public class DeferredRelayPlugin : Plugin
         var fullPath = GetFullPath(path);
         Directory.CreateDirectory(fullPath);
         _store = system.LoadStore(fullPath);
-        _actor = system.ActorSystem.ActorOf(
-            Props.Create(() => new DeferredRelayActor(system, _store, DeferredRelaySettings.Default)));
+        var queueState = DeferredRelayEngine.CreateQueueState(system, _store, DeferredRelaySettings.Default);
+        _actor = system.ActorSystem.ActorOf(Props.Create(() =>
+            new DeferredRelayActor(system, _store, DeferredRelaySettings.Default, queueState.Counter, queueState.Context)));
     }
 
     public override void Dispose()

--- a/plugins/DeferredRelay/DeferredRelaySettings.cs
+++ b/plugins/DeferredRelay/DeferredRelaySettings.cs
@@ -10,6 +10,8 @@
 // modifications are permitted.
 
 using Microsoft.Extensions.Configuration;
+using Neo.SmartContract.Native;
+using Neo.Wallets;
 
 namespace Neo.Plugins.DeferredRelay;
 
@@ -22,9 +24,10 @@ internal sealed class DeferredRelaySettings : IPluginSettings
     /// single drain pass cannot monopolize the Blockchain actor mailbox.
     /// </summary>
     public const uint DefaultMaxRelayPerCycle = 256u;
-
     public string Path { get; }
     public uint MaxTransactions { get; }
+    public uint MaxTransactionsPerSender { get; }
+    public long MinNetworkFee { get; }
     public uint CheckFrequency { get; }
     public UnhandledExceptionPolicy ExceptionPolicy { get; }
 
@@ -43,22 +46,53 @@ internal sealed class DeferredRelaySettings : IPluginSettings
         : this(
             section.GetValue("Path", "DeferredRelay_{0}")!,
             section.GetValue("MaxTransactions", 0u),
+            section.GetValue("MaxTransactionsPerSender", 0u),
+            GetGasAmount(section, "MinNetworkFee", 0L),
             section.GetValue("CheckFrequency", 0u),
             section.GetValue("UnhandledExceptionPolicy", UnhandledExceptionPolicy.Ignore))
     {
     }
 
-    private DeferredRelaySettings(string path, uint maxTransactions, uint checkFrequency, UnhandledExceptionPolicy exceptionPolicy)
+    private DeferredRelaySettings(string path, uint maxTransactions, uint maxTransactionsPerSender, long minNetworkFee, uint checkFrequency, UnhandledExceptionPolicy exceptionPolicy)
     {
+        Validate(maxTransactions, maxTransactionsPerSender);
         Path = path;
         MaxTransactions = maxTransactions;
+        MaxTransactionsPerSender = maxTransactionsPerSender;
+        MinNetworkFee = minNetworkFee;
         CheckFrequency = checkFrequency;
         ExceptionPolicy = exceptionPolicy;
+    }
+
+    /// <summary>
+    /// When <see cref="MaxTransactionsPerSender"/> is non-zero it must be strictly less than
+    /// <see cref="MaxTransactions"/> so a single sender cannot monopolize the whole queue cap.
+    /// </summary>
+    internal static void Validate(uint maxTransactions, uint maxTransactionsPerSender)
+    {
+        if (maxTransactionsPerSender == 0 || maxTransactions == 0)
+            return;
+        if (maxTransactionsPerSender >= maxTransactions)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxTransactionsPerSender),
+                maxTransactionsPerSender,
+                $"{nameof(MaxTransactionsPerSender)} must be less than {nameof(MaxTransactions)} when both are non-zero.");
+        }
     }
 
     public static void Load(IConfigurationSection section) =>
         Default = new DeferredRelaySettings(section);
 
-    internal static DeferredRelaySettings Create(uint maxTransactions, uint checkFrequency) =>
-        new("DeferredRelay_{0}", maxTransactions, checkFrequency, UnhandledExceptionPolicy.Ignore);
+    internal static DeferredRelaySettings Create(uint maxTransactions, uint checkFrequency, uint maxTransactionsPerSender = 0u, long minNetworkFee = 0L) =>
+        new("DeferredRelay_{0}", maxTransactions, maxTransactionsPerSender, minNetworkFee, checkFrequency, UnhandledExceptionPolicy.Ignore);
+
+    /// <summary>
+    /// Parses a GAS-denominated decimal from plugin configuration into datoshi (RpcServer <c>GetGasAmount</c>).
+    /// </summary>
+    private static long GetGasAmount(IConfigurationSection section, string key, long defaultValue)
+    {
+        if (!section.GetSection(key).Exists()) return defaultValue;
+        return (long)new BigDecimal(section.GetValue<decimal>(key), NativeContract.GAS.Decimals).Value;
+    }
 }

--- a/plugins/DeferredRelay/DeferredRelayVerification.cs
+++ b/plugins/DeferredRelay/DeferredRelayVerification.cs
@@ -49,7 +49,7 @@ internal static class DeferredRelayVerification
     {
         UInt160[] hashes = tx.GetScriptHashesForVerifying(snapshot);
         if (tx.Witnesses.Length != hashes.Length)
-            return VerifyResult.InvalidSignature;
+            return VerifyResult.Invalid;
         foreach (UInt160 hash in hashes)
             if (NativeContract.Policy.IsBlocked(snapshot, hash))
                 return VerifyResult.PolicyFail;

--- a/plugins/DeferredRelay/DeferredRelayVerification.cs
+++ b/plugins/DeferredRelay/DeferredRelayVerification.cs
@@ -1,0 +1,191 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// DeferredRelayVerification.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Extensions;
+using Neo.Ledger;
+using Neo.Network.P2P.Payloads;
+using Neo.Persistence;
+using Neo.SmartContract;
+using Neo.SmartContract.Manifest;
+using Neo.SmartContract.Native;
+using Neo.VM;
+using Neo.VM.Types;
+using System.Diagnostics.CodeAnalysis;
+using static Neo.SmartContract.Helper;
+
+namespace Neo.Plugins.DeferredRelay;
+
+/// <summary>
+/// State-dependent verification for deferred relay, mirroring <see cref="Transaction.VerifyStateDependent"/>
+/// but skipping the <see cref="VerifyResult.Expired"/> and <see cref="VerifyResult.NotYetValid"/> time gates.
+/// </summary>
+internal static class DeferredRelayVerification
+{
+    internal static bool IsDefinitiveRelayFailure(VerifyResult result) => result switch
+    {
+        VerifyResult.PolicyFail => true,
+        VerifyResult.InvalidScript => true,
+        VerifyResult.InvalidAttribute => true,
+        VerifyResult.InvalidSignature => true,
+        VerifyResult.Invalid => true,
+        VerifyResult.OverSize => true,
+        VerifyResult.InsufficientFunds => true,
+        _ => false,
+    };
+
+    internal static VerifyResult VerifyForOffer(
+        ProtocolSettings settings,
+        DataCache snapshot,
+        Transaction tx,
+        TransactionVerificationContext context)
+    {
+        UInt160[] hashes = tx.GetScriptHashesForVerifying(snapshot);
+        foreach (UInt160 hash in hashes)
+            if (NativeContract.Policy.IsBlocked(snapshot, hash))
+                return VerifyResult.PolicyFail;
+
+        if (!context.CheckTransaction(tx, [], snapshot))
+            return VerifyResult.InsufficientFunds;
+
+        long attributesFee = 0;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        foreach (TransactionAttribute attribute in tx.Attributes)
+        {
+            if (attribute.Type == TransactionAttributeType.NotaryAssisted && !settings.IsHardforkEnabled(Hardfork.HF_Echidna, height))
+                return VerifyResult.InvalidAttribute;
+            if (!attribute.Verify(snapshot, tx))
+                return VerifyResult.InvalidAttribute;
+            attributesFee += attribute.CalculateNetworkFee(snapshot, tx);
+        }
+
+        var netFeeDatoshi = tx.NetworkFee - (tx.Size * NativeContract.Policy.GetFeePerByte(snapshot)) - attributesFee;
+        if (netFeeDatoshi < 0) return VerifyResult.InsufficientFunds;
+
+        if (netFeeDatoshi > MaxVerificationGas) netFeeDatoshi = MaxVerificationGas;
+        var execFeeFactor = NativeContract.Policy.GetExecFeeFactor(settings, snapshot, height);
+        for (int i = 0; i < hashes.Length; i++)
+        {
+            if (IsSignatureContract(tx.Witnesses[i].VerificationScript.Span) &&
+                IsSingleSignatureInvocationScript(tx.Witnesses[i].InvocationScript, out _))
+            {
+                netFeeDatoshi -= execFeeFactor * SignatureContractCost();
+            }
+            else if (IsMultiSigContract(tx.Witnesses[i].VerificationScript.Span, out int m, out int n) &&
+                     IsMultiSignatureInvocationScript(m, tx.Witnesses[i].InvocationScript, out _))
+            {
+                netFeeDatoshi -= execFeeFactor * MultiSignatureContractCost(m, n);
+            }
+            else
+            {
+                if (!VerifyWitness(tx, settings, snapshot, hashes[i], tx.Witnesses[i], netFeeDatoshi, out long fee))
+                    return VerifyResult.Invalid;
+                netFeeDatoshi -= fee;
+            }
+
+            if (netFeeDatoshi < 0) return VerifyResult.InsufficientFunds;
+        }
+
+        return VerifyResult.Succeed;
+    }
+
+    private static bool IsMultiSignatureInvocationScript(int m, ReadOnlyMemory<byte> invocationScript,
+        [NotNullWhen(true)] out ReadOnlyMemory<byte>[]? sigs)
+    {
+        sigs = null;
+        ReadOnlySpan<byte> span = invocationScript.Span;
+        int i = 0;
+        var signatures = new List<ReadOnlyMemory<byte>>();
+        while (i < invocationScript.Length)
+        {
+            if (span[i++] != (byte)OpCode.PUSHDATA1) return false;
+            if (i + 65 > invocationScript.Length) return false;
+            if (span[i++] != 64) return false;
+            signatures.Add(invocationScript[i..(i + 64)]);
+            i += 64;
+        }
+
+        if (signatures.Count != m) return false;
+        sigs = signatures.ToArray();
+        return true;
+    }
+
+    private static bool IsSingleSignatureInvocationScript(ReadOnlyMemory<byte> invocationScript,
+        [NotNullWhen(true)] out ReadOnlyMemory<byte> sig)
+    {
+        sig = null;
+        if (invocationScript.Length != 66) return false;
+        ReadOnlySpan<byte> span = invocationScript.Span;
+        if (span[0] != (byte)OpCode.PUSHDATA1 || span[1] != 64) return false;
+        sig = invocationScript[2..66];
+        return true;
+    }
+
+    // Mirrors Neo.SmartContract.Helper.VerifyWitness (internal) for deferred-queue verification.
+    private static bool VerifyWitness(IVerifiable verifiable, ProtocolSettings settings, DataCache snapshot, UInt160 hash, Witness witness, long datoshi, out long fee)
+    {
+        fee = 0;
+        Script invocationScript;
+        try
+        {
+            invocationScript = new Script(witness.InvocationScript, true);
+        }
+        catch (BadScriptException)
+        {
+            return false;
+        }
+
+        using ApplicationEngine engine = ApplicationEngine.Create(TriggerType.Verification, verifiable, snapshot.CloneCache(), null, settings, datoshi);
+        if (witness.VerificationScript.Length == 0)
+        {
+            ContractState? cs = NativeContract.ContractManagement.GetContract(snapshot, hash);
+            if (cs is null) return false;
+            ContractMethodDescriptor? md = cs.Manifest.Abi.GetMethod(ContractBasicMethod.Verify, ContractBasicMethod.VerifyPCount);
+            if (md?.ReturnType != ContractParameterType.Boolean) return false;
+            engine.LoadContract(cs, md, CallFlags.ReadOnly);
+        }
+        else
+        {
+            if (NativeContract.IsNative(hash)) return false;
+            if (hash != witness.ScriptHash) return false;
+            Script verificationScript;
+            try
+            {
+                verificationScript = new Script(witness.VerificationScript, true);
+            }
+            catch (BadScriptException)
+            {
+                return false;
+            }
+
+            engine.LoadScript(verificationScript, initialPosition: 0, configureState: p =>
+            {
+                p.CallFlags = CallFlags.ReadOnly;
+                p.ScriptHash = hash;
+            });
+        }
+
+        engine.LoadScript(invocationScript, configureState: p => p.CallFlags = CallFlags.None);
+
+        if (engine.Execute() == VMState.FAULT) return false;
+        if (engine.ResultStack.Count != 1) return false;
+        try
+        {
+            if (!engine.ResultStack.Peek().GetBoolean()) return false;
+        }
+        catch
+        {
+            return false;
+        }
+
+        fee = engine.FeeConsumed;
+        return true;
+    }
+}

--- a/plugins/DeferredRelay/DeferredRelayVerification.cs
+++ b/plugins/DeferredRelay/DeferredRelayVerification.cs
@@ -48,6 +48,8 @@ internal static class DeferredRelayVerification
         TransactionVerificationContext context)
     {
         UInt160[] hashes = tx.GetScriptHashesForVerifying(snapshot);
+        if (tx.Witnesses.Length != hashes.Length)
+            return VerifyResult.InvalidSignature;
         foreach (UInt160 hash in hashes)
             if (NativeContract.Policy.IsBlocked(snapshot, hash))
                 return VerifyResult.PolicyFail;

--- a/plugins/DeferredRelay/README.md
+++ b/plugins/DeferredRelay/README.md
@@ -1,0 +1,90 @@
+# DeferredRelay
+
+Queues transactions that are **valid but not yet in the relay window** (`VerifyResult.NotYetValid`) and relays them automatically once they enter the allowed `ValidUntilBlock` window.
+
+On a standard Neo node, transactions whose `ValidUntilBlock` is too far in the future are rejected at relay time. DeferredRelay keeps those transactions in a **local plugin store** and retries relay on a schedule.
+
+---
+
+## ⚠️ Internal nodes only
+
+**This plugin should be used on internal / private nodes only — not on public RPC endpoints exposed to the open internet.**
+
+Public-facing nodes with DeferredRelay enabled become an **additional transaction ingress path** that ordinary nodes do not offer. Even with queue limits and fee checks, attackers can:
+
+- **Fill the local queue** with far-future transactions, consuming disk and verification CPU.
+- **Probe validation behavior** and queue state via RPC (`getpendingvaliduntilrelay`, `getrawpendingtx`).
+- **Bypass the normal “reject early” behavior** that protects mempools on the public network.
+
+Typical mitigations (`MaxTransactions`, `MaxTransactionsPerSender`, `MinNetworkFee`) reduce abuse but **do not eliminate** the extra attack surface. Operators who enable this plugin on a public RPC node often do not account for this risk.
+
+**Recommended deployment:** private infrastructure nodes (wallets, indexers, dApp backends) that you control, behind firewalls, with RPC access restricted to trusted clients.
+
+---
+
+## How it works
+
+```
+Relay attempt (RPC / P2P / CLI)
+        │
+        ▼
+Blockchain returns NotYetValid
+        │
+        ▼
+DeferredRelayActor ──► TryOffer (validate + persist to local store)
+        │
+        ▼
+On each Nth block (CheckFrequency)
+        │
+        ▼
+ProcessQueuedAsync ──► evict expired / invalid entries
+        │                relay txs that entered the window
+        ▼
+Blockchain.Relay (normal mempool path)
+```
+
+### Offer (enqueue)
+
+When the node relays a transaction and the result is `NotYetValid`, `DeferredRelayActor` calls `TryOffer`:
+
+1. Skip if the plugin is disabled, the tx is already in the mempool, or it is already queued.
+2. Enforce **queue capacity** (`MaxTransactions`), **per-sender cap** (`MaxTransactionsPerSender`), and **minimum network fee** (`MinNetworkFee`).
+3. Run **state-dependent verification** (`VerifyForOffer`) — same checks as `Transaction.VerifyStateDependent`, but **without** the `Expired` / `NotYetValid` time gates, so far-future transactions can still be validated for policy, balance, and witnesses.
+4. Persist the serialized transaction in the plugin’s dedicated store (`DeferredRelay_{networkId}`).
+
+### Process (dequeue & relay)
+
+After every `CheckFrequency` blocks:
+
+1. **Classify** all queued entries — remove expired, corrupt, below-min-fee, or state-invalid transactions.
+2. **Relay** transactions whose `ValidUntilBlock` is now within the allowed forward window.
+3. Cap relays per cycle (`MaxRelayPerCycle`, default 256) to avoid flooding the Blockchain actor mailbox.
+4. Remove successfully relayed entries (or entries that failed with a definitive error).
+
+On startup, the store is **compacted** so stale entries from a previous run do not occupy queue slots.
+
+---
+
+## Configuration
+
+Edit `DeferredRelay.json`. The plugin is **disabled by default** (`MaxTransactions` or `CheckFrequency` set to `0`).
+
+| Setting | Description |
+|---------|-------------|
+| `Path` | Local store path template (`DeferredRelay_{0}` → network id). |
+| `MaxTransactions` | Maximum queued transactions. Must be &gt; 0 to enable. |
+| `MaxTransactionsPerSender` | Per-sender queue cap (must be &lt; `MaxTransactions` when both are non-zero). `0` = unlimited per sender. |
+| `MinNetworkFee` | Minimum `NetworkFee` in GAS; txs below this are rejected / evicted. |
+| `CheckFrequency` | Process the queue every N blocks. Must be &gt; 0 to enable. |
+
+**Requires:** [RpcServer](https://github.com/neo-project/neo-node/tree/master/plugins/RpcServer) plugin (RPC methods below).
+
+---
+
+## RPC & CLI
+
+| Method / command | Description |
+|------------------|-------------|
+| `getpendingvaliduntilrelay` | Queue snapshot: height, settings, pending tx list. |
+| `getrawpendingtx` | Fetch a queued transaction by hash (base64 or verbose JSON). |
+| `list pending` | CLI equivalent of `getpendingvaliduntilrelay`. |

--- a/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
+++ b/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
@@ -314,6 +314,60 @@ public class UT_DeferredRelayEngine
     }
 
     [TestMethod]
+    public void CompactStore_RemovesExpiredCorruptAndVerifyFailures()
+    {
+        var store = new MemoryStore();
+        var settings = EnabledSettings(max: 10u, freq: 1u);
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
+        uint vub = height + maxInc + 100;
+
+        var expired = CreateRawTx(height, nonce: 70);
+        store.Put(expired.Hash.GetSpan().ToArray(), SerializeTx(expired));
+
+        var corruptKey = UInt256.Parse("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20").GetSpan().ToArray();
+        store.Put(corruptKey, [0xFF]);
+
+        var invalidWitness = CreateRawTx(vub, nonce: 71);
+        store.Put(invalidWitness.Hash.GetSpan().ToArray(), SerializeTx(invalidWitness));
+
+        var valid = CreateSignedTx(vub, nonce: 72);
+        store.Put(valid.Hash.GetSpan().ToArray(), SerializeTx(valid));
+
+        DeferredRelayEngine.CompactStore(_system, store, settings);
+
+        Assert.IsFalse(store.Contains(expired.Hash.GetSpan().ToArray()));
+        Assert.IsFalse(store.Contains(corruptKey));
+        Assert.IsFalse(store.Contains(invalidWitness.Hash.GetSpan().ToArray()));
+        Assert.IsTrue(store.Contains(valid.Hash.GetSpan().ToArray()));
+        Assert.AreEqual(1, DeferredRelayEngine.CountEntries(store));
+    }
+
+    [TestMethod]
+    public void CreateQueueState_CompactsStoreAndBootstrapsCounter()
+    {
+        var store = new MemoryStore();
+        var settings = EnabledSettings(max: 10u, freq: 1u);
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
+        uint vub = height + maxInc + 100;
+
+        var expired = CreateRawTx(height, nonce: 80);
+        store.Put(expired.Hash.GetSpan().ToArray(), SerializeTx(expired));
+        var valid = CreateSignedTx(vub, nonce: 81);
+        store.Put(valid.Hash.GetSpan().ToArray(), SerializeTx(valid));
+
+        var (counter, _) = DeferredRelayEngine.CreateQueueState(_system, store, settings);
+
+        Assert.IsFalse(store.Contains(expired.Hash.GetSpan().ToArray()));
+        Assert.IsTrue(store.Contains(valid.Hash.GetSpan().ToArray()));
+        Assert.AreEqual(1, counter.Value);
+        Assert.AreEqual(1, DeferredRelayEngine.CountEntries(store));
+    }
+
+    [TestMethod]
     public void DeferredRelayActor_BootstrapsCounter_FromExistingStoreEntries()
     {
         // Pre-seed store with `max` entries before starting the actor: the actor must bootstrap its
@@ -332,7 +386,9 @@ public class UT_DeferredRelayEngine
         store.Put(seed2.Hash.GetSpan().ToArray(), SerializeTx(seed2));
 
         var newTx = CreateSignedTx(vub, nonce: 93);
-        var actor = _system.ActorSystem.ActorOf(Props.Create(() => new DeferredRelayActor(_system, store, settings)));
+        var queueState = DeferredRelayEngine.CreateQueueState(_system, store, settings);
+        var actor = _system.ActorSystem.ActorOf(Props.Create(() =>
+            new DeferredRelayActor(_system, store, settings, queueState.Counter, queueState.Context)));
         try
         {
             // Publish a NotYetValid RelayResult; if the bootstrap is wrong (counter==0), the actor would accept it.
@@ -631,7 +687,7 @@ public class UT_DeferredRelayEngine
         uint height = NativeContract.Ledger.CurrentIndex(snapshot);
         uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
 
-        var tx = CreateRawTx(height + maxInc + 100);
+        var tx = CreateSignedTx(height + maxInc + 100, nonce: 601);
         byte[] key = tx.Hash.GetSpan().ToArray();
         store.Put(key, SerializeTx(tx));
 
@@ -642,7 +698,7 @@ public class UT_DeferredRelayEngine
             // Give the actor system a brief window to publish any stray RelayResult events.
             Thread.Sleep(100);
 
-            Assert.IsTrue(store.Contains(key), "Tx beyond the relay window must remain in store");
+            Assert.IsTrue(store.Contains(key), "Valid tx beyond the relay window must remain in store");
             lock (locker)
             {
                 Assert.IsFalse(
@@ -671,7 +727,7 @@ public class UT_DeferredRelayEngine
 
         uint vub = height + 1; // height < vub <= height + maxInc
         Assert.IsTrue(vub > height && vub <= height + maxInc);
-        var tx = CreateRawTx(vub);
+        var tx = CreateSignedTx(vub, nonce: 602);
         byte[] key = tx.Hash.GetSpan().ToArray();
         store.Put(key, SerializeTx(tx));
 
@@ -807,6 +863,28 @@ public class UT_DeferredRelayEngine
         var tx2 = CreateSignedTx(vub, nonce: 12);
         Assert.IsFalse(DeferredRelayEngine.TryOffer(_system, store, settings, tx2, VerifyResult.NotYetValid, queueContext: queueContext));
         Assert.AreEqual(1, store.Find(null).Count());
+    }
+
+    [TestMethod]
+    public void ProcessQueued_EvictsStateInvalidFarFutureEntry()
+    {
+        var store = new MemoryStore();
+        var settings = EnabledSettings();
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
+        uint vub = height + maxInc + 50;
+
+        var tx = CreateSignedTx(vub, nonce: 600);
+        byte[] key = tx.Hash.GetSpan().ToArray();
+        store.Put(key, SerializeTx(tx));
+
+        var queueContext = DeferredQueueContext.Bootstrap(store);
+        BlockAccount(_account.ScriptHash);
+
+        DeferredRelayEngine.ProcessQueuedAsync(_system, store, settings, queueContext: queueContext).GetAwaiter().GetResult();
+
+        Assert.IsFalse(store.Contains(key));
     }
 
     [TestMethod]

--- a/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
+++ b/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
@@ -24,6 +24,7 @@ using Neo.SmartContract.Native;
 using Neo.VM;
 using Neo.Wallets;
 using Neo.Wallets.NEP6;
+using System.Numerics;
 using System.Reflection;
 
 namespace Neo.Plugins.DeferredRelay.Tests;
@@ -41,10 +42,21 @@ public class UT_DeferredRelayEngine
         _system = TestBlockchain.GetSystem();
         _wallet = TestUtils.GenerateTestWallet("pwd");
         _account = _wallet.CreateAccount();
+        FundAccount(_account.ScriptHash, 100_000_000 * NativeContract.GAS.Factor);
     }
 
-    private static DeferredRelaySettings EnabledSettings(uint max = 10000u, uint freq = 1u) => DeferredRelaySettings.Create(max, freq);
+    private static DeferredRelaySettings EnabledSettings(uint max = 10000u, uint freq = 1u, uint maxPerSender = 0u, long minNetworkFee = 0L) =>
+        DeferredRelaySettings.Create(max, freq, maxPerSender, minNetworkFee);
     private static DeferredRelaySettings DisabledSettings() => DeferredRelaySettings.Create(0u, 1u);
+
+    private void FundAccount(UInt160 scriptHash, BigInteger balance)
+    {
+        var snapshot = _system.GetSnapshotCache();
+        var key = new KeyBuilder(NativeContract.GAS.Id, 20).Add(scriptHash);
+        var entry = snapshot.GetAndChange(key, () => new StorageItem(new AccountState()));
+        entry.GetInteroperable<AccountState>().Balance = balance;
+        snapshot.Commit();
+    }
 
     private static void RunPersistProcessing(NeoSystem system, IStore store, DeferredRelaySettings settings, Block block)
     {
@@ -56,16 +68,11 @@ public class UT_DeferredRelayEngine
     private Transaction CreateSignedTx(uint validUntilBlock, uint nonce = 42)
     {
         var snapshot = _system.StoreView;
-        var tx = new Transaction
-        {
-            Version = 0,
-            Nonce = nonce,
-            ValidUntilBlock = validUntilBlock,
-            Signers = [new Signer { Account = _account.ScriptHash, Scopes = WitnessScope.CalledByEntry }],
-            Attributes = [],
-            Script = new byte[] { (byte)OpCode.RET },
-            Witnesses = [],
-        };
+        var tx = _wallet.MakeTransaction(snapshot, new byte[] { (byte)OpCode.RET },
+            sender: _account.ScriptHash,
+            cosigners: [new Signer { Account = _account.ScriptHash, Scopes = WitnessScope.CalledByEntry }]);
+        tx.Nonce = nonce;
+        tx.ValidUntilBlock = validUntilBlock;
         var ctx = new ContractParametersContext(snapshot, tx, _system.Settings.Network);
         Assert.IsTrue(_wallet.Sign(ctx));
         tx.Witnesses = ctx.GetWitnesses();
@@ -727,6 +734,225 @@ public class UT_DeferredRelayEngine
         using (var writer = new BinaryWriter(ms))
             ((ISerializable)tx).Serialize(writer);
         return ms.ToArray();
+    }
+
+    [TestMethod]
+    public void TryOffer_Rejects_WhenNetworkFeeBelowMin()
+    {
+        var store = new MemoryStore();
+        var minFee = (long)new BigDecimal(1M, NativeContract.GAS.Decimals).Value;
+        var settings = EnabledSettings(minNetworkFee: minFee);
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
+        var tx = CreateManualSignedTx(_wallet, _account, height + maxInc + 5, nonce: 2);
+
+        Assert.IsLessThan(minFee, tx.NetworkFee);
+        Assert.IsFalse(DeferredRelayEngine.TryOffer(_system, store, settings, tx, VerifyResult.NotYetValid));
+        Assert.AreEqual(0, store.Find(null).Count());
+    }
+
+    [TestMethod]
+    public void TryOffer_Rejects_WhenSenderHasNoGas()
+    {
+        var store = new MemoryStore();
+        var settings = EnabledSettings();
+        var unfundedWallet = TestUtils.GenerateTestWallet("unfunded");
+        var unfundedAccount = unfundedWallet.CreateAccount();
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
+        var tx = CreateManualSignedTx(unfundedWallet, unfundedAccount, height + maxInc + 5, nonce: 1);
+
+        Assert.IsFalse(DeferredRelayEngine.TryOffer(_system, store, settings, tx, VerifyResult.NotYetValid));
+        Assert.AreEqual(0, store.Find(null).Count());
+    }
+
+    [TestMethod]
+    public void TryOffer_MaxTransactionsPerSender_RejectsExcess()
+    {
+        var store = new MemoryStore();
+        var settings = EnabledSettings(maxPerSender: 2u);
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
+        uint vub = height + maxInc + 10;
+        var queueContext = new DeferredQueueContext();
+
+        Assert.IsTrue(DeferredRelayEngine.TryOffer(_system, store, settings, CreateSignedTx(vub, nonce: 1), VerifyResult.NotYetValid, queueContext: queueContext));
+        Assert.IsTrue(DeferredRelayEngine.TryOffer(_system, store, settings, CreateSignedTx(vub, nonce: 2), VerifyResult.NotYetValid, queueContext: queueContext));
+        Assert.IsFalse(DeferredRelayEngine.TryOffer(_system, store, settings, CreateSignedTx(vub, nonce: 3), VerifyResult.NotYetValid, queueContext: queueContext));
+        Assert.AreEqual(2, store.Find(null).Count());
+    }
+
+    [TestMethod]
+    public void TryOffer_SameSenderFeeAggregation_RejectsWhenBalanceInsufficient()
+    {
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
+        uint vub = height + maxInc + 10;
+
+        var probe = CreateSignedTx(vub, nonce: 99);
+        var oneTxCost = (BigInteger)(probe.SystemFee + probe.NetworkFee);
+        FundAccount(_account.ScriptHash, oneTxCost);
+
+        var store = new MemoryStore();
+        var settings = EnabledSettings();
+        var queueContext = new DeferredQueueContext();
+
+        var tx1 = CreateSignedTx(vub, nonce: 11);
+        Assert.IsTrue(DeferredRelayEngine.TryOffer(_system, store, settings, tx1, VerifyResult.NotYetValid, queueContext: queueContext));
+
+        var tx2 = CreateSignedTx(vub, nonce: 12);
+        Assert.IsFalse(DeferredRelayEngine.TryOffer(_system, store, settings, tx2, VerifyResult.NotYetValid, queueContext: queueContext));
+        Assert.AreEqual(1, store.Find(null).Count());
+    }
+
+    [TestMethod]
+    public void ProcessQueued_DefinitiveRelayFailure_InsufficientFunds_RemovesEntry()
+    {
+        var tx = CreateSignedTx(InWindowVub(), nonce: 501);
+        AssertRelayEvictsQueuedEntry(tx, beforeRelay: () => FundAccount(_account.ScriptHash, BigInteger.Zero));
+    }
+
+    [TestMethod]
+    public void ProcessQueued_DefinitiveRelayFailure_InvalidScript_RemovesEntry()
+    {
+        var tx = CreateRawTx(InWindowVub(), nonce: 502);
+        tx.Script = new byte[] { 0xFF };
+        AssertRelayEvictsQueuedEntry(tx);
+    }
+
+    [TestMethod]
+    public void ProcessQueued_DefinitiveRelayFailure_OverSize_RemovesEntry()
+    {
+        var tx = CreateRawTx(InWindowVub(), nonce: 503);
+        tx.Script = new byte[Transaction.MaxTransactionSize];
+        AssertRelayEvictsQueuedEntry(tx);
+    }
+
+    [TestMethod]
+    public void ProcessQueued_DefinitiveRelayFailure_InvalidSignature_RemovesEntry()
+    {
+        var tx = CreateSignedTx(InWindowVub(), nonce: 504);
+        tx.Witnesses =
+        [
+            new Witness
+            {
+                InvocationScript = new byte[] { (byte)OpCode.PUSHDATA1, 64 }.Concat(new byte[64]).ToArray(),
+                VerificationScript = tx.Witnesses[0].VerificationScript,
+            },
+        ];
+        AssertRelayEvictsQueuedEntry(tx);
+    }
+
+    [TestMethod]
+    public void ProcessQueued_DefinitiveRelayFailure_Invalid_RemovesEntry()
+    {
+        var tx = CreateRawTx(InWindowVub(), nonce: 505);
+        AssertRelayEvictsQueuedEntry(tx);
+    }
+
+    [TestMethod]
+    public void ProcessQueued_DefinitiveRelayFailure_InvalidAttribute_RemovesEntry()
+    {
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        var tx = CreateSignedTx(InWindowVub(), nonce: 506);
+        tx.Attributes = [new NotValidBefore { Height = height + 100 }];
+        var ctx = new ContractParametersContext(snapshot, tx, _system.Settings.Network);
+        Assert.IsTrue(_wallet.Sign(ctx));
+        tx.Witnesses = ctx.GetWitnesses();
+        AssertRelayEvictsQueuedEntry(tx);
+    }
+
+    [TestMethod]
+    public void ProcessQueued_DefinitiveRelayFailure_PolicyFail_RemovesEntry()
+    {
+        var tx = CreateSignedTx(InWindowVub(), nonce: 507);
+        AssertRelayEvictsQueuedEntry(tx, beforeRelay: () => BlockAccount(_account.ScriptHash));
+    }
+
+    [TestMethod]
+    public void IsDefinitiveRelayFailure_MatchesExpectedResults()
+    {
+        foreach (var result in new[]
+                 {
+                     VerifyResult.PolicyFail,
+                     VerifyResult.InvalidScript,
+                     VerifyResult.InvalidAttribute,
+                     VerifyResult.InvalidSignature,
+                     VerifyResult.Invalid,
+                     VerifyResult.OverSize,
+                     VerifyResult.InsufficientFunds,
+                 })
+            Assert.IsTrue(DeferredRelayVerification.IsDefinitiveRelayFailure(result), $"{result} should evict");
+
+        foreach (var result in new[]
+                 {
+                     VerifyResult.Succeed,
+                     VerifyResult.AlreadyInPool,
+                     VerifyResult.AlreadyExists,
+                     VerifyResult.OutOfMemory,
+                     VerifyResult.HasConflicts,
+                     VerifyResult.NotYetValid,
+                     VerifyResult.Unknown,
+                 })
+            Assert.IsFalse(DeferredRelayVerification.IsDefinitiveRelayFailure(result), $"{result} should retain");
+    }
+
+    private uint InWindowVub()
+    {
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
+        Assert.AreNotEqual(0u, maxInc);
+        return height + 1;
+    }
+
+    private void BlockAccount(UInt160 scriptHash)
+    {
+        var snapshot = _system.GetSnapshotCache();
+        var key = new KeyBuilder(NativeContract.Policy.Id, 15).Add(scriptHash);
+        snapshot.Add(key, new StorageItem(Array.Empty<byte>()));
+        snapshot.Commit();
+        Assert.IsTrue(NativeContract.Policy.IsBlocked(snapshot, scriptHash));
+    }
+
+    private void AssertRelayEvictsQueuedEntry(Transaction tx, Action beforeRelay = null)
+    {
+        var store = new MemoryStore();
+        var settings = EnabledSettings();
+        byte[] key = tx.Hash.GetSpan().ToArray();
+        store.Put(key, SerializeTx(tx));
+
+        beforeRelay?.Invoke();
+
+        var queueContext = DeferredQueueContext.Bootstrap(store);
+        DeferredRelayEngine.ProcessQueuedAsync(_system, store, settings, queueContext: queueContext).GetAwaiter().GetResult();
+
+        Assert.IsFalse(store.Contains(key), $"Queued entry should be evicted after definitive relay failure ({tx.Hash})");
+    }
+
+    private Transaction CreateManualSignedTx(NEP6Wallet wallet, WalletAccount account, uint validUntilBlock, uint nonce)
+    {
+        var snapshot = _system.StoreView;
+        var tx = new Transaction
+        {
+            Version = 0,
+            Nonce = nonce,
+            ValidUntilBlock = validUntilBlock,
+            Signers = [new Signer { Account = account.ScriptHash, Scopes = WitnessScope.CalledByEntry }],
+            Attributes = [],
+            Script = new byte[] { (byte)OpCode.RET },
+            Witnesses = [],
+        };
+        tx.NetworkFee = Math.Max(tx.NetworkFee, tx.Size * NativeContract.Policy.GetFeePerByte(snapshot));
+        var ctx = new ContractParametersContext(snapshot, tx, _system.Settings.Network);
+        Assert.IsTrue(wallet.Sign(ctx));
+        tx.Witnesses = ctx.GetWitnesses();
+        return tx;
     }
 
     private Transaction CreateRawTx(uint validUntilBlock, uint nonce = 0) => new()

--- a/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
+++ b/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
@@ -220,6 +220,25 @@ public class UT_DeferredRelayEngine
     }
 
     [TestMethod]
+    public void TryOffer_Fallback_CompactsBeforeCapacityCheck()
+    {
+        var store = new MemoryStore();
+        var settings = EnabledSettings(max: 1u);
+        var snapshot = _system.StoreView;
+        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
+
+        var expired = CreateRawTx(height, nonce: 99);
+        store.Put(expired.Hash.GetSpan().ToArray(), SerializeTx(expired));
+        Assert.AreEqual(1, DeferredRelayEngine.CountEntries(store));
+
+        var valid = CreateSignedTx(height + maxInc + 10, nonce: 100);
+        Assert.IsTrue(DeferredRelayEngine.TryOffer(_system, store, settings, valid, VerifyResult.NotYetValid));
+        Assert.IsFalse(store.Contains(expired.Hash.GetSpan().ToArray()));
+        Assert.AreEqual(1, DeferredRelayEngine.CountEntries(store));
+    }
+
+    [TestMethod]
     public void TryOffer_WhenAtMaxTransactions_RejectsNewHash()
     {
         var store = new MemoryStore();
@@ -802,8 +821,9 @@ public class UT_DeferredRelayEngine
         uint height = NativeContract.Ledger.CurrentIndex(snapshot);
         uint maxInc = snapshot.GetMaxValidUntilBlockIncrement(_system.Settings);
         var tx = CreateManualSignedTx(_wallet, _account, height + maxInc + 5, nonce: 2);
+        tx.NetworkFee = minFee - 1;
 
-        Assert.IsLessThan(minFee, tx.NetworkFee);
+        Assert.IsTrue(tx.NetworkFee < minFee);
         Assert.IsFalse(DeferredRelayEngine.TryOffer(_system, store, settings, tx, VerifyResult.NotYetValid));
         Assert.AreEqual(0, store.Find(null).Count());
     }

--- a/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelaySettings.cs
+++ b/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelaySettings.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Microsoft.Extensions.Configuration;
+using Neo.SmartContract.Native;
 using System.Text;
 
 namespace Neo.Plugins.DeferredRelay.Tests;
@@ -47,12 +48,14 @@ public class UT_DeferredRelaySettings
           "PluginConfiguration": {
             "Path": "DeferredRelay_{0}",
             "MaxTransactions": 8192,
+            "MaxTransactionsPerSender": 16,
             "CheckFrequency": 5
           }
         }
         """;
         DeferredRelaySettings.Load(BuildSection(json));
         Assert.AreEqual(8192u, DeferredRelaySettings.Default.MaxTransactions);
+        Assert.AreEqual(16u, DeferredRelaySettings.Default.MaxTransactionsPerSender);
         Assert.AreEqual(5u, DeferredRelaySettings.Default.CheckFrequency);
         Assert.IsTrue(DeferredRelaySettings.Default.Enabled);
     }
@@ -79,6 +82,54 @@ public class UT_DeferredRelaySettings
         }
         """));
         Assert.IsFalse(DeferredRelaySettings.Default.Enabled);
+    }
+
+    [TestMethod]
+    public void Validate_RejectsPerSenderNotLessThanMax()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+            DeferredRelaySettings.Create(maxTransactions: 16u, checkFrequency: 1u, maxTransactionsPerSender: 16u));
+        Assert.AreEqual("maxTransactionsPerSender", ex.ParamName);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+            DeferredRelaySettings.Create(maxTransactions: 16u, checkFrequency: 1u, maxTransactionsPerSender: 32u));
+    }
+
+    [TestMethod]
+    public void Validate_AllowsPerSenderZeroOrDisabledMax()
+    {
+        DeferredRelaySettings.Create(maxTransactions: 16u, checkFrequency: 1u, maxTransactionsPerSender: 0u);
+        DeferredRelaySettings.Create(maxTransactions: 0u, checkFrequency: 1u, maxTransactionsPerSender: 100u);
+        DeferredRelaySettings.Create(maxTransactions: 16u, checkFrequency: 1u, maxTransactionsPerSender: 15u);
+    }
+
+    [TestMethod]
+    public void Load_RejectsInvalidPerSenderCap()
+    {
+        const string json = """
+        {
+          "PluginConfiguration": {
+            "MaxTransactions": 8,
+            "MaxTransactionsPerSender": 8,
+            "CheckFrequency": 1
+          }
+        }
+        """;
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => DeferredRelaySettings.Load(BuildSection(json)));
+    }
+
+    [TestMethod]
+    public void LoadsMinNetworkFee()
+    {
+        const string json = """
+        {
+          "PluginConfiguration": {
+            "MinNetworkFee": 0.0001
+          }
+        }
+        """;
+        DeferredRelaySettings.Load(BuildSection(json));
+        Assert.AreEqual((long)new BigDecimal(0.0001M, NativeContract.GAS.Decimals).Value, DeferredRelaySettings.Default.MinNetworkFee);
     }
 
     [TestMethod]


### PR DESCRIPTION
Fix known issue in `DeferredRelay` and improve some verification workflow.
1. `NotYetValid` early return — Queued txs previously skipped `Policy/funds/witness` checks; we now run `state-dependent` verification before `store.Put`, skipping only the time gates.
2. Pre-offer filtering — `VerifyForOffer` mirrors core `VerifyStateDependent` (Policy, funds, network fee, witness) so far-future/no-GAS txs are rejected at enqueue time.
3. `Per-sender` cap — `MaxTransactionsPerSender` limits how many deferred txs one sender can queue.
4. Sender fee aggregation — DeferredQueueContext sums queued fees per sender so multiple queued txs cannot exceed balance individually.
5. Relay failure eviction — Definitive relay failures (PolicyFail, Invalid*, OverSize, InsufficientFunds) remove entries instead of retrying until expiry.
6. Min network fee — `MinNetworkFee` (In `GAS`, same format as RpcServer `MaxFee`) rejects low-fee spam before enqueue.