### PR TITLE
RpcServer: fix InvalidTxSize error regression

### DIFF
--- a/plugins/RpcServer/RpcServer.Node.cs
+++ b/plugins/RpcServer/RpcServer.Node.cs
@@ -213,7 +213,7 @@ partial class RpcServer
             RpcError.InvalidParams.WithData("Invalid Transaction Format: Expected Base64-encoded string"));
 
         if (txData.Length > Transaction.MaxTransactionSize)
-            throw new RpcException(RpcError.InvalidParams.WithData("Transaction size exceeds the maximum allowed."));
+            throw new RpcException(RpcError.InvalidSize.WithData("Transaction size exceeds the maximum allowed."));
 
         var tx = Result.Ok_Or(
             () => txData.AsSerializable<Transaction>(),

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
@@ -245,7 +245,7 @@ partial class UT_RpcServer
         var exception = Assert.ThrowsExactly<RpcException>(() => _ = _rpcServer.SendRawTransaction(txString),
             "Should throw RpcException for invalid format transaction");
         // Oversized transaction will not pass the deserialization.
-        Assert.AreEqual(RpcError.InvalidParams.Code, exception.HResult);
+        Assert.AreEqual(RpcError.InvalidSize.Code, exception.HResult);
     }
 
     [TestMethod]


### PR DESCRIPTION
If transaction has invalid size, -509 code should be returned by the RPC server according to the NEP-23. The behaviour was changed by https://github.com/neo-project/neo-node/pull/1065.

Should be a part of v3.10.0.