### PR TITLE
tests: fix build warning

### DIFF
--- a/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
+++ b/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
@@ -823,7 +823,7 @@ public class UT_DeferredRelayEngine
         var tx = CreateManualSignedTx(_wallet, _account, height + maxInc + 5, nonce: 2);
         tx.NetworkFee = minFee - 1;
 
-        Assert.IsTrue(tx.NetworkFee < minFee);
+        Assert.IsLessThan(minFee, tx.NetworkFee);
         Assert.IsFalse(DeferredRelayEngine.TryOffer(_system, store, settings, tx, VerifyResult.NotYetValid));
         Assert.AreEqual(0, store.Find(null).Count());
     }


### PR DESCRIPTION
Fix the following build warning:
```
  Neo.Plugins.DeferredRelay.Tests net10.0 succeeded with 1 warning(s) (2.7s) → tests/Neo.Plugins.DeferredRelay.Tests/bin/Release/net10.0/publish/
    /home/anna/Documents/GitProjects/neo-project/neo-node/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs(826,9): warning MSTEST0037: Use 'Assert.IsLessThan' instead of 'Assert.IsTrue' (https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0037)
```