### PR TITLE
Fix DeferredRelay startup on fresh node stores

### DIFF
--- a/plugins/DeferredRelay/DeferredRelayEngine.cs
+++ b/plugins/DeferredRelay/DeferredRelayEngine.cs
@@ -265,6 +265,26 @@ internal static class DeferredRelayEngine
             store.Delete(key);
     }
 
+    internal static bool TryGetCurrentHeight(IStore store, out uint height)
+    {
+        using var snapshot = new StoreCache(store);
+        return TryGetCurrentHeight(snapshot, out height);
+    }
+
+    private static bool TryGetCurrentHeight(IReadOnlyStore snapshot, out uint height)
+    {
+        try
+        {
+            height = NativeContract.Ledger.CurrentIndex(snapshot);
+            return true;
+        }
+        catch (KeyNotFoundException)
+        {
+            height = 0;
+            return false;
+        }
+    }
+
     /// <summary>
     /// Returns store keys to evict and surviving transactions (stable store order, fee-aggregation aware).
     /// </summary>
@@ -282,7 +302,8 @@ internal static class DeferredRelayEngine
             return;
 
         var snapshot = system.StoreView;
-        uint height = NativeContract.Ledger.CurrentIndex(snapshot);
+        if (!TryGetCurrentHeight(snapshot, out uint height))
+            return;
         List<(byte[] Key, Transaction Tx)> candidates = [];
 
         foreach ((byte[] key, byte[] value) in store.Find())

--- a/plugins/DeferredRelay/DeferredRelayEngine.cs
+++ b/plugins/DeferredRelay/DeferredRelayEngine.cs
@@ -265,13 +265,7 @@ internal static class DeferredRelayEngine
             store.Delete(key);
     }
 
-    internal static bool TryGetCurrentHeight(IStore store, out uint height)
-    {
-        using var snapshot = new StoreCache(store);
-        return TryGetCurrentHeight(snapshot, out height);
-    }
-
-    private static bool TryGetCurrentHeight(IReadOnlyStore snapshot, out uint height)
+    internal static bool TryGetCurrentHeight(IReadOnlyStore snapshot, out uint height)
     {
         try
         {

--- a/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
+++ b/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
@@ -367,8 +367,9 @@ public class UT_DeferredRelayEngine
     public void TryGetCurrentHeight_UninitializedLedger_ReturnsFalse()
     {
         var store = new MemoryStore();
+        using var snapshot = new StoreCache(store);
 
-        Assert.IsFalse(DeferredRelayEngine.TryGetCurrentHeight(store, out uint height));
+        Assert.IsFalse(DeferredRelayEngine.TryGetCurrentHeight(snapshot, out uint height));
         Assert.AreEqual(0u, height);
     }
 

--- a/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
+++ b/tests/Neo.Plugins.DeferredRelay.Tests/UT_DeferredRelayEngine.cs
@@ -364,6 +364,15 @@ public class UT_DeferredRelayEngine
     }
 
     [TestMethod]
+    public void TryGetCurrentHeight_UninitializedLedger_ReturnsFalse()
+    {
+        var store = new MemoryStore();
+
+        Assert.IsFalse(DeferredRelayEngine.TryGetCurrentHeight(store, out uint height));
+        Assert.AreEqual(0u, height);
+    }
+
+    [TestMethod]
     public void CreateQueueState_CompactsStoreAndBootstrapsCounter()
     {
         var store = new MemoryStore();


### PR DESCRIPTION
Fixes #1076 

## Summary

This PR makes `DeferredRelay` safe to enable when `neo-cli` starts against a fresh/empty node store.

`DeferredRelayPlugin.OnSystemLoaded()` bootstraps queue state before `Blockchain.Initialize()` persists genesis. When the plugin is enabled, that startup path calls `Ledger.CurrentIndex()` during queue compaction. On a fresh store, the ledger current-block state does not exist yet, causing `KeyNotFoundException` and preventing startup.

The fix treats an uninitialized ledger as "not ready for queue classification yet" and skips startup compaction in that case. Once genesis is persisted, normal `PersistCompleted` handling can process the queue according to `CheckFrequency`.

## Testing

Not run locally. Verified manually with a fresh private-net Docker startup that previously failed with `DeferredRelay` enabled.