### PR TITLE
Fix: The `start` should be the inclusive max key if `Backward` scan

### DIFF
--- a/plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
+++ b/plugins/LevelDBStore/IO/Data/LevelDB/Helper.cs
@@ -16,7 +16,7 @@ namespace Neo.IO.Data.LevelDB;
 
 public static class Helper
 {
-    public static IEnumerable<(byte[], byte[])> Seek(this DB db, ReadOptions options, byte[]? keyOrPrefix, SeekDirection direction)
+    public static IEnumerable<(byte[] Key, byte[] Value)> Seek(this DB db, ReadOptions options, byte[]? keyOrPrefix, SeekDirection direction)
     {
         keyOrPrefix ??= [];
 

--- a/plugins/LevelDBStore/Plugins/Storage/Snapshot.cs
+++ b/plugins/LevelDBStore/Plugins/Storage/Snapshot.cs
@@ -79,51 +79,22 @@ internal class Snapshot : IStoreSnapshot, IEnumerable<KeyValuePair<byte[], byte[
         ArgumentNullException.ThrowIfNull(start);
         ArgumentNullException.ThrowIfNull(end);
 
-        if (start.AsSpan().SequenceCompareTo(end) >= 0)
+        var order = start.AsSpan().SequenceCompareTo(end);
+        if ((direction == SeekDirection.Forward && order >= 0) ||
+            (direction == SeekDirection.Backward && order <= 0))
+        {
             yield break;
-
-        using var iterator = _db.CreateIterator(_readOptions);
-
-        if (direction == SeekDirection.Forward)
-        {
-            iterator.Seek(start);
-
-            while (iterator.Valid())
-            {
-                var key = iterator.Key();
-                if (key is null) break;
-
-                if (key.AsSpan().SequenceCompareTo(end) >= 0)
-                    break;
-
-                yield return (key, iterator.Value()!);
-                iterator.Next();
-            }
         }
-        else
+
+        foreach (var item in _db.Seek(_readOptions, start, direction))
         {
-            iterator.Seek(end);
-
-            if (!iterator.Valid())
+            order = item.Key.AsSpan().SequenceCompareTo(end);
+            if ((direction == SeekDirection.Forward && order >= 0) ||
+                (direction == SeekDirection.Backward && order <= 0))
             {
-                iterator.SeekToLast();
+                yield break; // end is the exclusive max key if forward, or the exclusive min key if backward
             }
-            else
-            {
-                iterator.Prev();
-            }
-
-            while (iterator.Valid())
-            {
-                var key = iterator.Key();
-                if (key is null) break;
-
-                if (key.AsSpan().SequenceCompareTo(start) < 0)
-                    break;
-
-                yield return (key, iterator.Value()!);
-                iterator.Prev();
-            }
+            yield return item;
         }
     }
 

--- a/plugins/LevelDBStore/Plugins/Storage/Store.cs
+++ b/plugins/LevelDBStore/Plugins/Storage/Store.cs
@@ -83,57 +83,26 @@ internal class Store : IStore, IEnumerable<KeyValuePair<byte[], byte[]>>
         ArgumentNullException.ThrowIfNull(start);
         ArgumentNullException.ThrowIfNull(end);
 
-        if (start.AsSpan().SequenceCompareTo(end) >= 0)
+        var order = start.AsSpan().SequenceCompareTo(end);
+        if ((direction == SeekDirection.Forward && order >= 0) ||
+            (direction == SeekDirection.Backward && order <= 0))
+        {
             yield break;
-
-        using var iterator = _db.CreateIterator(ReadOptions.Default);
-
-        if (direction == SeekDirection.Forward)
-        {
-            iterator.Seek(start);
-
-            while (iterator.Valid())
-            {
-                var key = iterator.Key();
-                if (key is null) break;
-
-                if (key.AsSpan().SequenceCompareTo(end) >= 0)
-                    break;
-
-                yield return (key, iterator.Value()!);
-                iterator.Next();
-            }
         }
-        else
+
+        foreach (var item in _db.Seek(ReadOptions.Default, start, direction))
         {
-            iterator.Seek(end);
-
-            if (!iterator.Valid())
+            order = item.Key.AsSpan().SequenceCompareTo(end);
+            if ((direction == SeekDirection.Forward && order >= 0) ||
+                (direction == SeekDirection.Backward && order <= 0))
             {
-                iterator.SeekToLast();
+                yield break; // end is the exclusive max key if forward, or the exclusive min key if backward
             }
-            else
-            {
-                iterator.Prev();
-            }
-
-            while (iterator.Valid())
-            {
-                var key = iterator.Key();
-                if (key is null) break;
-
-                if (key.AsSpan().SequenceCompareTo(start) < 0)
-                    break;
-
-                yield return (key, iterator.Value()!);
-                iterator.Prev();
-            }
+            yield return item;
         }
     }
 
-    public IEnumerator<KeyValuePair<byte[], byte[]>> GetEnumerator() =>
-        _db.GetEnumerator();
+    public IEnumerator<KeyValuePair<byte[], byte[]>> GetEnumerator() => _db.GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() =>
-        GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/plugins/LevelDBStore/Plugins/Storage/Store.cs
+++ b/plugins/LevelDBStore/Plugins/Storage/Store.cs
@@ -102,7 +102,9 @@ internal class Store : IStore, IEnumerable<KeyValuePair<byte[], byte[]>>
         }
     }
 
-    public IEnumerator<KeyValuePair<byte[], byte[]>> GetEnumerator() => _db.GetEnumerator();
+    public IEnumerator<KeyValuePair<byte[], byte[]>> GetEnumerator() =>
+        _db.GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() =>
+        GetEnumerator();
 }

--- a/plugins/RocksDBStore/Plugins/Storage/Snapshot.cs
+++ b/plugins/RocksDBStore/Plugins/Storage/Snapshot.cs
@@ -62,17 +62,15 @@ internal class Snapshot : IStoreSnapshot
     public IEnumerable<(byte[] Key, byte[] Value)> Find(byte[]? keyOrPrefix, SeekDirection direction)
     {
         keyOrPrefix ??= [];
+
         using var it = _db.NewIterator(readOptions: _options);
+
         if (direction == SeekDirection.Forward)
-        {
             for (it.Seek(keyOrPrefix); it.Valid(); it.Next())
                 yield return (it.Key(), it.Value());
-        }
         else
-        {
             for (it.SeekForPrev(keyOrPrefix); it.Valid(); it.Prev())
                 yield return (it.Key(), it.Value());
-        }
     }
 
     public IEnumerable<(byte[] Key, byte[] Value)> FindRange(byte[] start, byte[] end, SeekDirection direction = SeekDirection.Forward)

--- a/plugins/RocksDBStore/Plugins/Storage/Snapshot.cs
+++ b/plugins/RocksDBStore/Plugins/Storage/Snapshot.cs
@@ -62,15 +62,17 @@ internal class Snapshot : IStoreSnapshot
     public IEnumerable<(byte[] Key, byte[] Value)> Find(byte[]? keyOrPrefix, SeekDirection direction)
     {
         keyOrPrefix ??= [];
-
         using var it = _db.NewIterator(readOptions: _options);
-
         if (direction == SeekDirection.Forward)
+        {
             for (it.Seek(keyOrPrefix); it.Valid(); it.Next())
                 yield return (it.Key(), it.Value());
+        }
         else
+        {
             for (it.SeekForPrev(keyOrPrefix); it.Valid(); it.Prev())
                 yield return (it.Key(), it.Value());
+        }
     }
 
     public IEnumerable<(byte[] Key, byte[] Value)> FindRange(byte[] start, byte[] end, SeekDirection direction = SeekDirection.Forward)
@@ -78,43 +80,22 @@ internal class Snapshot : IStoreSnapshot
         ArgumentNullException.ThrowIfNull(start);
         ArgumentNullException.ThrowIfNull(end);
 
-        if (start.AsSpan().SequenceCompareTo(end) >= 0)
+        var order = start.AsSpan().SequenceCompareTo(end);
+        if ((direction == SeekDirection.Forward && order >= 0) ||
+            (direction == SeekDirection.Backward && order <= 0))
+        {
             yield break;
-
-        using var it = _db.NewIterator(readOptions: _options);
-
-        if (direction == SeekDirection.Forward)
-        {
-            for (it.Seek(start); it.Valid(); it.Next())
-            {
-                var key = it.Key();
-                if (key.AsSpan().SequenceCompareTo(end) >= 0)
-                    break;
-
-                yield return (key, it.Value());
-            }
         }
-        else
+
+        foreach (var item in Find(start, direction))
         {
-            it.Seek(end);
-
-            if (!it.Valid())
+            order = item.Key.AsSpan().SequenceCompareTo(end);
+            if ((direction == SeekDirection.Forward && order >= 0) ||
+                (direction == SeekDirection.Backward && order <= 0))
             {
-                it.SeekToLast();
+                yield break; // end is the exclusive max key if forward, or the exclusive min key if backward
             }
-            else
-            {
-                it.Prev();
-            }
-
-            for (; it.Valid(); it.Prev())
-            {
-                var key = it.Key();
-                if (key.AsSpan().SequenceCompareTo(start) < 0)
-                    break;
-
-                yield return (key, it.Value());
-            }
+            yield return item;
         }
     }
 

--- a/plugins/RocksDBStore/Plugins/Storage/Store.cs
+++ b/plugins/RocksDBStore/Plugins/Storage/Store.cs
@@ -43,17 +43,14 @@ internal class Store : IStore
     public IEnumerable<(byte[] Key, byte[] Value)> Find(byte[]? keyOrPrefix, SeekDirection direction = SeekDirection.Forward)
     {
         keyOrPrefix ??= [];
+
         using var it = _db.NewIterator();
         if (direction == SeekDirection.Forward)
-        {
             for (it.Seek(keyOrPrefix); it.Valid(); it.Next())
                 yield return (it.Key(), it.Value());
-        }
         else
-        {
             for (it.SeekForPrev(keyOrPrefix); it.Valid(); it.Prev())
                 yield return (it.Key(), it.Value());
-        }
     }
 
     public IEnumerable<(byte[] Key, byte[] Value)> FindRange(byte[] start, byte[] end, SeekDirection direction = SeekDirection.Forward)

--- a/plugins/RocksDBStore/Plugins/Storage/Store.cs
+++ b/plugins/RocksDBStore/Plugins/Storage/Store.cs
@@ -43,14 +43,17 @@ internal class Store : IStore
     public IEnumerable<(byte[] Key, byte[] Value)> Find(byte[]? keyOrPrefix, SeekDirection direction = SeekDirection.Forward)
     {
         keyOrPrefix ??= [];
-
         using var it = _db.NewIterator();
         if (direction == SeekDirection.Forward)
+        {
             for (it.Seek(keyOrPrefix); it.Valid(); it.Next())
                 yield return (it.Key(), it.Value());
+        }
         else
+        {
             for (it.SeekForPrev(keyOrPrefix); it.Valid(); it.Prev())
                 yield return (it.Key(), it.Value());
+        }
     }
 
     public IEnumerable<(byte[] Key, byte[] Value)> FindRange(byte[] start, byte[] end, SeekDirection direction = SeekDirection.Forward)
@@ -58,43 +61,22 @@ internal class Store : IStore
         ArgumentNullException.ThrowIfNull(start);
         ArgumentNullException.ThrowIfNull(end);
 
-        if (start.AsSpan().SequenceCompareTo(end) >= 0)
+        var order = start.AsSpan().SequenceCompareTo(end);
+        if ((direction == SeekDirection.Forward && order >= 0) ||
+            (direction == SeekDirection.Backward && order <= 0))
+        {
             yield break;
-
-        using var it = _db.NewIterator();
-
-        if (direction == SeekDirection.Forward)
-        {
-            for (it.Seek(start); it.Valid(); it.Next())
-            {
-                var key = it.Key();
-                if (key.AsSpan().SequenceCompareTo(end) >= 0)
-                    break;
-
-                yield return (key, it.Value());
-            }
         }
-        else
+
+        foreach (var item in Find(start, direction))
         {
-            it.Seek(end);
-
-            if (!it.Valid())
+            order = item.Key.AsSpan().SequenceCompareTo(end);
+            if ((direction == SeekDirection.Forward && order >= 0) ||
+                (direction == SeekDirection.Backward && order <= 0))
             {
-                it.SeekToLast();
+                yield break; // end is the exclusive max key if forward, or the exclusive min key if backward
             }
-            else
-            {
-                it.Prev();
-            }
-
-            for (; it.Valid(); it.Prev())
-            {
-                var key = it.Key();
-                if (key.AsSpan().SequenceCompareTo(start) < 0)
-                    break;
-
-                yield return (key, it.Value());
-            }
+            yield return item;
         }
     }
 

--- a/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
+++ b/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
@@ -9,8 +9,6 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
-#pragma warning disable CS0618 // Type or member is obsolete
-
 using Neo.Persistence;
 using Neo.Persistence.Providers;
 
@@ -48,16 +46,14 @@ public class StoreTest
     public void TestMemory()
     {
         using var store = new MemoryStore();
-        // Test all with the same store
 
+        // Test all with the same store
         TestStorage(store);
 
         // Test with different storages
-
         TestPersistence(store);
 
         // Test snapshot
-
         TestSnapshot(store);
         TestMultiSnapshot(store);
     }
@@ -68,15 +64,12 @@ public class StoreTest
         using var store = s_levelDbStore.GetStore(Path_leveldb);
 
         // Test all with the same store
-
         TestStorage(store);
 
         // Test with different storages
-
         TestPersistence(store);
 
         // Test snapshot
-
         TestSnapshot(store);
         TestMultiSnapshot(store);
     }
@@ -87,15 +80,12 @@ public class StoreTest
         using var store = s_rocksDBStore.GetStore(Path_rocksdb);
 
         // Test all with the same store
-
         TestStorage(store);
 
         // Test with different storages
-
         TestPersistence(store);
 
         // Test snapshot
-
         TestSnapshot(store);
         TestMultiSnapshot(store);
     }
@@ -183,7 +173,6 @@ public class StoreTest
         Assert.IsFalse(store.Contains(key1));
 
         // Test seek in order
-
         store.Put([0x00, 0x00, 0x04], [0x04]);
         store.Put([0x00, 0x00, 0x00], [0x00]);
         store.Put([0x00, 0x00, 0x01], [0x01]);
@@ -191,7 +180,6 @@ public class StoreTest
         store.Put([0x00, 0x00, 0x03], [0x03]);
 
         // Seek Forward
-
         var entries = store.Find([0x00, 0x00, 0x02], SeekDirection.Forward).ToArray();
         Assert.HasCount(3, entries);
         CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x02 }, entries[0].Key);
@@ -201,8 +189,40 @@ public class StoreTest
         CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x04 }, entries[2].Key);
         CollectionAssert.AreEqual(new byte[] { 0x04 }, entries[2].Value);
 
-        // Seek Backward
+        // FindRange Forward
+        entries = store.FindRange([0x00, 0x00, 0x02], [0x00, 0x00, 0x04], SeekDirection.Forward).ToArray();
+        Assert.HasCount(2, entries);
+        CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x02 }, entries[0].Key);
+        CollectionAssert.AreEqual(new byte[] { 0x02 }, entries[0].Value);
+        CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x03 }, entries[1].Key);
+        CollectionAssert.AreEqual(new byte[] { 0x03 }, entries[1].Value);
 
+        // FindRange Backward
+        entries = store.FindRange([0x00, 0x00, 0x02], [0x00, 0x00, 0x04], SeekDirection.Backward).ToArray();
+        Assert.HasCount(0, entries); // start is the max key if backward, so no entries
+
+        entries = store.FindRange([0x00, 0x00, 0x04], [0x00, 0x00, 0x02], SeekDirection.Backward).ToArray();
+        Assert.HasCount(2, entries);
+        CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x04 }, entries[0].Key);
+        CollectionAssert.AreEqual(new byte[] { 0x04 }, entries[0].Value);
+        CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x03 }, entries[1].Key);
+        CollectionAssert.AreEqual(new byte[] { 0x03 }, entries[1].Value);
+
+        // FindRange Backward with start is greater than the last key
+        entries = store.FindRange([0x00, 0x00, 0xFF], [0x00, 0x00, 0x03], SeekDirection.Backward).ToArray();
+        Assert.HasCount(1, entries);
+        CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x04 }, entries[0].Key);
+        CollectionAssert.AreEqual(new byte[] { 0x04 }, entries[0].Value);
+
+        // FindRange Forward with end is greater than the last key
+        entries = store.FindRange([0x00, 0x00, 0x03], [0x00, 0x00, 0xFF], SeekDirection.Forward).ToArray();
+        Assert.HasCount(2, entries);
+        CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x03 }, entries[0].Key);
+        CollectionAssert.AreEqual(new byte[] { 0x03 }, entries[0].Value);
+        CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x04 }, entries[1].Key);
+        CollectionAssert.AreEqual(new byte[] { 0x04 }, entries[1].Value);
+
+        // Seek Backward
         entries = store.Find([0x00, 0x00, 0x02], SeekDirection.Backward).ToArray();
         Assert.HasCount(3, entries);
         CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x02 }, entries[0].Key);
@@ -268,7 +288,6 @@ public class StoreTest
             Assert.IsEmpty(entries);
 
             // Seek Backward
-
             entries = snapshot.Find([0x00, 0x00, 0x02], SeekDirection.Backward).ToArray();
             Assert.HasCount(2, entries);
             CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x01 }, entries[0].Key);
@@ -333,5 +352,3 @@ public class StoreTest
         Assert.IsNull(retvalue);
     }
 }
-
-#pragma warning restore CS0618 // Type or member is obsolete

--- a/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
+++ b/tests/Neo.Plugins.Storage.Tests/StoreTest.cs
@@ -9,6 +9,8 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 using Neo.Persistence;
 using Neo.Persistence.Providers;
 
@@ -46,14 +48,16 @@ public class StoreTest
     public void TestMemory()
     {
         using var store = new MemoryStore();
-
         // Test all with the same store
+
         TestStorage(store);
 
         // Test with different storages
+
         TestPersistence(store);
 
         // Test snapshot
+
         TestSnapshot(store);
         TestMultiSnapshot(store);
     }
@@ -64,12 +68,15 @@ public class StoreTest
         using var store = s_levelDbStore.GetStore(Path_leveldb);
 
         // Test all with the same store
+
         TestStorage(store);
 
         // Test with different storages
+
         TestPersistence(store);
 
         // Test snapshot
+
         TestSnapshot(store);
         TestMultiSnapshot(store);
     }
@@ -80,12 +87,15 @@ public class StoreTest
         using var store = s_rocksDBStore.GetStore(Path_rocksdb);
 
         // Test all with the same store
+
         TestStorage(store);
 
         // Test with different storages
+
         TestPersistence(store);
 
         // Test snapshot
+
         TestSnapshot(store);
         TestMultiSnapshot(store);
     }
@@ -173,6 +183,7 @@ public class StoreTest
         Assert.IsFalse(store.Contains(key1));
 
         // Test seek in order
+
         store.Put([0x00, 0x00, 0x04], [0x04]);
         store.Put([0x00, 0x00, 0x00], [0x00]);
         store.Put([0x00, 0x00, 0x01], [0x01]);
@@ -180,6 +191,7 @@ public class StoreTest
         store.Put([0x00, 0x00, 0x03], [0x03]);
 
         // Seek Forward
+
         var entries = store.Find([0x00, 0x00, 0x02], SeekDirection.Forward).ToArray();
         Assert.HasCount(3, entries);
         CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x02 }, entries[0].Key);
@@ -223,6 +235,7 @@ public class StoreTest
         CollectionAssert.AreEqual(new byte[] { 0x04 }, entries[1].Value);
 
         // Seek Backward
+
         entries = store.Find([0x00, 0x00, 0x02], SeekDirection.Backward).ToArray();
         Assert.HasCount(3, entries);
         CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x02 }, entries[0].Key);
@@ -288,6 +301,7 @@ public class StoreTest
             Assert.IsEmpty(entries);
 
             // Seek Backward
+
             entries = snapshot.Find([0x00, 0x00, 0x02], SeekDirection.Backward).ToArray();
             Assert.HasCount(2, entries);
             CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x01 }, entries[0].Key);
@@ -316,6 +330,27 @@ public class StoreTest
             CollectionAssert.AreEqual(new byte[] { 0x01 }, entries[0].Value);
             CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x00 }, entries[1].Key);
             CollectionAssert.AreEqual(new byte[] { 0x00 }, entries[1].Value);
+
+            // FindRange Forward
+            entries = snapshot.FindRange([0x00, 0x00, 0x00], [0x00, 0x01, 0x02], SeekDirection.Forward).ToArray();
+            Assert.HasCount(2, entries);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x00 }, entries[0].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x00 }, entries[0].Value);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x01 }, entries[1].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x01 }, entries[1].Value);
+
+            // FindRange Backward
+            entries = snapshot.FindRange([0x00, 0x01, 0x02], [0x00, 0x00, 0x00], SeekDirection.Backward).ToArray();
+            Assert.HasCount(2, entries);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x01, 0x02 }, entries[0].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x02 }, entries[0].Value);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x00, 0x01 }, entries[1].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x01 }, entries[1].Value);
+
+            entries = snapshot.FindRange([0x00, 0x01, 0xFF], [0x00, 0x00, 0x01], SeekDirection.Backward).ToArray();
+            Assert.HasCount(1, entries);
+            CollectionAssert.AreEqual(new byte[] { 0x00, 0x01, 0x02 }, entries[0].Key);
+            CollectionAssert.AreEqual(new byte[] { 0x02 }, entries[0].Value);
 
             // Test keys with different lengths
             searchKey = [0x00, 0x01];
@@ -352,3 +387,5 @@ public class StoreTest
         Assert.IsNull(retvalue);
     }
 }
+
+#pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION

The `start` should be the inclusive max key if `Backward` scan, and the inclusive min key if `Forward` scan.
The current implementation treats the `start` as the min key if `Backward` scan.

