### PR TITLE
v3.10.1

### DIFF
--- a/plugins/Directory.Build.props
+++ b/plugins/Directory.Build.props
@@ -10,7 +10,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/neo-project/neo-node.git</RepositoryUrl>
     <PackageTags>NEO;Blockchain</PackageTags>
-    <VersionPrefix>3.10.1</VersionPrefix>
+    <Version>3.10.1</Version>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>$(PackageId)</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="3.10.0" />
+    <PackageReference Include="Neo" Version="3.10.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/plugins/RestServer/RestServer.csproj
+++ b/plugins/RestServer/RestServer.csproj
@@ -5,11 +5,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/plugins/RocksDBStore/RocksDBStore.csproj
+++ b/plugins/RocksDBStore/RocksDBStore.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="rocksdb" Version="10.4.2.63147" />
+    <PackageReference Include="rocksdb" Version="10.10.1.1747" />
   </ItemGroup>
 
 </Project>

--- a/plugins/SQLiteWallet/SQLiteWallet.csproj
+++ b/plugins/SQLiteWallet/SQLiteWallet.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/plugins/SignClient/SignClient.csproj
+++ b/plugins/SignClient/SignClient.csproj
@@ -5,10 +5,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Google.Protobuf" Version="3.33.4" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
+		<PackageReference Include="Google.Protobuf" Version="3.35.1" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
 		<!-- NOTE: Need install rosetta2 on macOS ARM64 -->
-		<PackageReference Include="Grpc.Tools" Version="2.76.0" PrivateAssets="all" />
+		<PackageReference Include="Grpc.Tools" Version="2.82.0" PrivateAssets="all" />
 		<PackageReference Include="Ookii.VmSockets" Version="1.0.0" />
 	</ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Copyright>2015-2026 The Neo Project</Copyright>
     <Authors>The Neo Project</Authors>
     <TargetFramework>net10.0</TargetFramework>
-    <VersionPrefix>3.10.1</VersionPrefix>
+    <Version>3.10.1</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/src/Neo.CLI/Docker/Dockerfile
+++ b/src/Neo.CLI/Docker/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /neo
 COPY prepare-node.sh .
 RUN dos2unix prepare-node.sh && chmod +x prepare-node.sh
 
-ARG CLI_VERSION=v3.10.0
+ARG CLI_VERSION=v3.10.1
 ARG PLUGIN_VERSION=
 ENV NEO_CLI_DIR=neo-cli-${CLI_VERSION}
 RUN if [ -z "$PLUGIN_VERSION" ]; then \

--- a/src/Neo.CLI/Docker/README.md
+++ b/src/Neo.CLI/Docker/README.md
@@ -1,41 +1,41 @@
 # Neo CLI Docker Usage Examples
 
-## Example 1: Install CLI v3.10.0 (with matching plugins)
+## Example 1: Install CLI v3.10.1 (with matching plugins)
 
 ```bash
-# Build the image (v3.10.0 is the default)
-docker build -t v3.10.0 .
+# Build the image (v3.10.1 is the default)
+docker build -t v3.10.1 .
 
 # Run the container
-docker run -d -p 10332:10332 --name neo-node v3.10.0
+docker run -d -p 10332:10332 --name neo-node v3.10.1
 
 # Enter the container and test
 docker exec -it neo-node bash
 curl -X POST http://localhost:10332 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}'
 ```
 
-## Example 2: Install CLI v3.10.0 with Plugin v3.9.2
+## Example 2: Install CLI v3.10.1 with Plugin v3.10.0
 
 ```bash
 # Build the image
-docker build -t v3.10.0-plugins-3.9.2 --build-arg PLUGIN_VERSION=v3.9.2 .
+docker build -t v3.10.1-plugins-3.10.0 --build-arg PLUGIN_VERSION=v3.10.0 .
 
 # Run the container
-docker run -d -p 10332:10332 --name neo-node v3.10.0-plugins-3.9.2
+docker run -d -p 10332:10332 --name neo-node v3.10.1-plugins-3.10.0
 
 # Enter the container and test
 docker exec -it neo-node bash
 curl -X POST http://localhost:10332 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"getblockcount","params":[],"id":1}'
 ```
 
-## Example 3: Install CLI v3.9.2 with Plugin v3.9.0
+## Example 3: Install CLI v3.10.0 with Plugin v3.10.0
 
 ```bash
 # Build the image
-docker build -t v3.9.2-plugins-3.9.0 --build-arg CLI_VERSION=v3.9.2 --build-arg PLUGIN_VERSION=v3.9.0 .
+docker build -t v3.10.0-plugins-3.10.0 --build-arg CLI_VERSION=v3.10.0 --build-arg PLUGIN_VERSION=v3.10.0 .
 
 # Run the container
-docker run -d -p 10332:10332 --name neo-node v3.9.2-plugins-3.9.0
+docker run -d -p 10332:10332 --name neo-node v3.10.0-plugins-3.10.0
 
 # Enter the container and test
 docker exec -it neo-node bash

--- a/src/Neo.CLI/Neo.CLI.csproj
+++ b/src/Neo.CLI/Neo.CLI.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="3.10.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.2" />
+    <PackageReference Include="Neo" Version="3.10.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Neo.CLI/config.fs.mainnet.json
+++ b/src/Neo.CLI/config.fs.mainnet.json
@@ -45,7 +45,8 @@
       "HF_Cockatrice": 3500000,
       "HF_Domovoi": 3500000,
       "HF_Echidna": 3519099,
-      "HF_Faun": 19725000
+      "HF_Faun": 19725000,
+      "HF_Gorgon": 20700000
     },
     "StandbyCommittee": [
       "026fa34ec057d74c2fdf1a18e336d0bd597ea401a0b2ad57340d5c220d09f44086",

--- a/src/Neo.CLI/config.fs.testnet.json
+++ b/src/Neo.CLI/config.fs.testnet.json
@@ -45,7 +45,8 @@
       "HF_Cockatrice": 0,
       "HF_Domovoi": 0,
       "HF_Echidna": 0,
-      "HF_Faun": 19340000
+      "HF_Faun": 19340000,
+      "HF_Gorgon": 20200000
     },
     "StandbyCommittee": [
       "0337f5f45e5be5aeae4a919d0787fcb743656560949061d5b8b05509b85ffbfd53",

--- a/src/Neo.CLI/config.json
+++ b/src/Neo.CLI/config.json
@@ -42,7 +42,8 @@
       "HF_Cockatrice": 5450000,
       "HF_Domovoi": 5570000,
       "HF_Echidna": 7300000,
-      "HF_Faun": 8800000
+      "HF_Faun": 8800000,
+      "HF_Gorgon": 12020000
     },
     "InitialGasDistribution": 5200000000000000,
     "ValidatorsCount": 7,

--- a/src/Neo.CLI/config.mainnet.json
+++ b/src/Neo.CLI/config.mainnet.json
@@ -42,7 +42,8 @@
       "HF_Cockatrice": 5450000,
       "HF_Domovoi": 5570000,
       "HF_Echidna": 7300000,
-      "HF_Faun": 8800000
+      "HF_Faun": 8800000,
+      "HF_Gorgon": 12020000
     },
     "InitialGasDistribution": 5200000000000000,
     "ValidatorsCount": 7,

--- a/src/Neo.CLI/config.testnet.json
+++ b/src/Neo.CLI/config.testnet.json
@@ -42,7 +42,8 @@
       "HF_Cockatrice": 3967000,
       "HF_Domovoi": 4144000,
       "HF_Echidna": 5870000,
-      "HF_Faun": 12960000
+      "HF_Faun": 12960000,
+      "HF_Gorgon": 17960000
     },
     "InitialGasDistribution": 5200000000000000,
     "ValidatorsCount": 7,

--- a/src/Neo.ConsoleService/Neo.ConsoleService.csproj
+++ b/src/Neo.ConsoleService/Neo.ConsoleService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.2" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.0.2" />
+    <PackageReference Include="MSTest" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Neo.Plugins.DBFTPlugin.Tests/Neo.Plugins.DBFTPlugin.Tests.csproj
+++ b/tests/Neo.Plugins.DBFTPlugin.Tests/Neo.Plugins.DBFTPlugin.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.MsTest" Version="1.5.0" />
+    <PackageReference Include="Akka.TestKit.MsTest" Version="1.5.67" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Neo.Plugins.OracleService.Tests/Neo.Plugins.OracleService.Tests.csproj
+++ b/tests/Neo.Plugins.OracleService.Tests/Neo.Plugins.OracleService.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit" Version="1.5.58" />
+    <PackageReference Include="Akka.TestKit" Version="1.5.70" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Neo.Plugins.RestServer.Tests/Neo.Plugins.RestServer.Tests.csproj
+++ b/tests/Neo.Plugins.RestServer.Tests/Neo.Plugins.RestServer.Tests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Neo.Plugins.SQLiteWallet.Tests/Neo.Plugins.SQLiteWallet.Tests.csproj
+++ b/tests/Neo.Plugins.SQLiteWallet.Tests/Neo.Plugins.SQLiteWallet.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
     <ProjectReference Include="..\..\plugins\SQLiteWallet\SQLiteWallet.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Explicitly pinning SQLitePCLRaw.lib.e_sqlite3 to v3.53.3 upgrades the bundled SQLite native library to a version that fixes the known security vulnerability ([CVE-2025-6965](https://github.com/advisories/GHSA-2m69-gcr7-jv3q)) in older transitive dependencies pulled in by EF Core’s SQLite provider. It's an core denpendency of the latest Microsoft.EntityFrameworkCore.Sqlite v10.0.9, but Microsoft.EntityFrameworkCore.Sqlite is using v2.1.11.