### PR TITLE
Fix ut race condition

### DIFF
--- a/plugins/Directory.Build.props
+++ b/plugins/Directory.Build.props
@@ -10,7 +10,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/neo-project/neo-node.git</RepositoryUrl>
     <PackageTags>NEO;Blockchain</PackageTags>
-    <Version>3.10.1</Version>
+    <VersionPrefix>3.10.2</VersionPrefix>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>$(PackageId)</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Copyright>2015-2026 The Neo Project</Copyright>
     <Authors>The Neo Project</Authors>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>3.10.1</Version>
+    <VersionPrefix>3.10.2</VersionPrefix>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/tests/Neo.Plugins.DBFTPlugin.Tests/UT_ConsensusService.cs
+++ b/tests/Neo.Plugins.DBFTPlugin.Tests/UT_ConsensusService.cs
@@ -374,8 +374,7 @@ public class UT_ConsensusService : TestKit
         var primaryServiceRef = ActorOfAsTestActorRef<ConsensusService>(ConsensusService.Props(neoSystem, settings, new TestSigner()));
         var primaryActor = primaryServiceRef.UnderlyingActor;
 
-        primaryServiceRef.Tell(new ConsensusService.Start());
-
+        InvokeConsensusMethod(primaryActor, "OnStart");
         Assert.IsTrue(GetBooleanField(primaryActor, "started"));
 
         var primaryContext = GetConsensusContext(primaryActor);
@@ -448,9 +447,11 @@ public class UT_ConsensusService : TestKit
         var serviceRef = ActorOfAsTestActorRef<ConsensusService>(ConsensusService.Props(neoSystem, settings, new TestSigner()));
         var actor = serviceRef.UnderlyingActor;
 
-        serviceRef.Tell(new ConsensusService.Start());
+        InvokeConsensusMethod(actor, "OnStart");
+        Assert.IsTrue(GetBooleanField(actor, "started"));
 
         var context = GetConsensusContext(actor);
+        Assert.IsNotNull(context.Validators);
         context.ChangeViewPayloads ??= new ExtensiblePayload[context.Validators.Length];
         context.LastChangeViewPayloads ??= new ExtensiblePayload[context.Validators.Length];
 


### PR DESCRIPTION
Close https://github.com/neo-project/neo-node/issues/1059
Fixed a flaky race in `TestConsensusServiceExecutesWarningAndLifecyclePaths` where the test accessed `context.Validators` before async Tell(Start) finished initializing consensus. Replaced it with a synchronous OnStart() call and an explicit Validators null check so CI runs deterministically.