### PR TITLE
ToJson max length in rpc node

### DIFF
--- a/plugins/RpcServer/RcpServerSettings.cs
+++ b/plugins/RpcServer/RcpServerSettings.cs
@@ -37,6 +37,7 @@ public record RpcServersSettings
     public string[] TrustedAuthorities { get; init; } = [];
     public int MaxConcurrentConnections { get; init; } = 40;
     public int MaxRequestBodySize { get; init; } = 1 * 1024 * 1024;
+    public int MaxItemResponseSize { get; init; } = ushort.MaxValue;
     public string RpcUser { get; init; } = string.Empty;
     public string RpcPass { get; init; } = string.Empty;
     public bool EnableCors { get; init; } = true;
@@ -89,6 +90,7 @@ public record RpcServersSettings
             MaxGasInvoke = GetGasAmount(section, "MaxGasInvoke", @default.MaxGasInvoke),
             MaxFee = GetGasAmount(section, "MaxFee", @default.MaxFee),
             MaxIteratorResultItems = section.GetValue("MaxIteratorResultItems", @default.MaxIteratorResultItems),
+            MaxItemResponseSize = section.GetValue("MaxItemResponseSize", @default.MaxItemResponseSize),
             MaxStackSize = section.GetValue("MaxStackSize", @default.MaxStackSize),
             DisabledMethods = GetStrings(section, "DisabledMethods"),
             MaxConcurrentConnections = section.GetValue("MaxConcurrentConnections", @default.MaxConcurrentConnections),

--- a/plugins/RpcServer/RcpServerSettings.cs
+++ b/plugins/RpcServer/RcpServerSettings.cs
@@ -10,6 +10,7 @@
 // modifications are permitted.
 
 using Microsoft.Extensions.Configuration;
+using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Native;
 using System.Net;
 
@@ -37,7 +38,7 @@ public record RpcServersSettings
     public string[] TrustedAuthorities { get; init; } = [];
     public int MaxConcurrentConnections { get; init; } = 40;
     public int MaxRequestBodySize { get; init; } = 1 * 1024 * 1024;
-    public int MaxItemResponseSize { get; init; } = ushort.MaxValue;
+    public int MaxItemResponseSize { get; init; } = Transaction.MaxTransactionSize;
     public string RpcUser { get; init; } = string.Empty;
     public string RpcPass { get; init; } = string.Empty;
     public bool EnableCors { get; init; } = true;

--- a/plugins/RpcServer/RpcServer.SmartContract.cs
+++ b/plugins/RpcServer/RpcServer.SmartContract.cs
@@ -80,7 +80,7 @@ partial class RpcServer
                 {
                     ["eventname"] = n.EventName,
                     ["contract"] = n.ScriptHash.ToString(),
-                    ["state"] = ToJson(n.State, session),
+                    ["state"] = ToJson(n.State, session, settings.MaxItemResponseSize),
                 };
             }));
             if (useDiagnostic)
@@ -98,7 +98,7 @@ partial class RpcServer
             {
                 try
                 {
-                    stack.Add(ToJson(item, session));
+                    stack.Add(ToJson(item, session, settings.MaxItemResponseSize));
                 }
                 catch (Exception ex)
                 {
@@ -173,9 +173,9 @@ partial class RpcServer
         return array;
     }
 
-    private static JObject ToJson(StackItem item, Session session)
+    private JObject ToJson(StackItem item, Session session, int maxItemResponseSize)
     {
-        var json = item.ToJson();
+        var json = item.ToJson(maxItemResponseSize);
         if (item is InteropInterface interopInterface && interopInterface.GetInterface<object>() is IIterator iterator)
         {
             Guid id = Guid.NewGuid();

--- a/plugins/RpcServer/RpcServer.json
+++ b/plugins/RpcServer/RpcServer.json
@@ -17,6 +17,7 @@
         "MaxGasInvoke": 20,
         "MaxFee": 0.1,
         "MaxRequestBodySize": 1048576,
+        "MaxItemResponseSize": 102400,
         "MaxConcurrentConnections": 40,
         "MaxIteratorResultItems": 100,
         "MaxStackSize": 65535,


### PR DESCRIPTION
This pull request adds a new setting to control the maximum allowed size of individual item responses in the RPC server and updates the relevant code to enforce this limit. The main changes introduce the `MaxItemResponseSize` configuration property and ensure that JSON serialization of stack items respects this limit.

**Configuration Enhancements:**

* Added a new `MaxItemResponseSize` property to the `RpcServersSettings` record, defaulting to `ushort.MaxValue`, allowing configuration of the maximum size for item responses.
* Updated the `Load` method to read the `MaxItemResponseSize` value from the configuration section.

**Enforcing Response Size Limits:**

* Modified calls to `ToJson` in `GetInvokeResult` to pass the configured `MaxItemResponseSize`, ensuring that event and stack item serialization respects the size limit. [[1]](diffhunk://#diff-8f3dae74fc0523e664fd6521c1debcd63e603e12415a4acdfd602b24c14f04f2L83-R83) [[2]](diffhunk://#diff-8f3dae74fc0523e664fd6521c1debcd63e603e12415a4acdfd602b24c14f04f2L101-R101)
* Updated the `ToJson` method to accept the `maxItemResponseSize` parameter and pass it to the stack item's `ToJson` method, enforcing the response size limit during serialization.