### PR TITLE
Limit invalid tx size

### DIFF
--- a/plugins/DBFTPlugin/Consensus/ConsensusContext.MakePayload.cs
+++ b/plugins/DBFTPlugin/Consensus/ConsensusContext.MakePayload.cs
@@ -84,8 +84,8 @@ partial class ConsensusContext
         // Iterate transaction until reach the size or maximum system fee
         foreach (Transaction tx in txs)
         {
-            if (InvalidTransactions.TryGetValue(tx.Hash, out var hashset))
-                if (hashset.Count > F) continue;
+            if (InvalidTransactions.TryGet(tx.Hash, out var hashset))
+                if (hashset.Value.Count > F) continue;
 
             // Check if maximum block size has been already exceeded with the current selected set
             blockSize += tx.Size;

--- a/plugins/DBFTPlugin/Consensus/ConsensusContext.cs
+++ b/plugins/DBFTPlugin/Consensus/ConsensusContext.cs
@@ -13,6 +13,7 @@ using Neo.Cryptography;
 using Neo.Cryptography.ECC;
 using Neo.Extensions;
 using Neo.IO;
+using Neo.IO.Caching;
 using Neo.Ledger;
 using Neo.Network.P2P.Payloads;
 using Neo.Persistence;
@@ -26,6 +27,15 @@ namespace Neo.Plugins.DBFTPlugin.Consensus;
 
 public sealed partial class ConsensusContext : IDisposable, ISerializable
 {
+    public record UnvalidTxCacheItem(UInt256 Key, HashSet<ECPoint> Value);
+    public class InvalidCache(int maxCapacity) : FIFOCache<UInt256, UnvalidTxCacheItem>(maxCapacity)
+    {
+        protected override UInt256 GetKeyForItem(UnvalidTxCacheItem item)
+        {
+            return item.Key;
+        }
+    }
+
     /// <summary>
     /// Key for saving consensus state.
     /// </summary>
@@ -50,7 +60,7 @@ public sealed partial class ConsensusContext : IDisposable, ISerializable
     /// Store all verified unsorted transactions' senders' fee currently in the consensus context.
     /// </summary>
     public TransactionVerificationContext VerificationContext = new();
-    public Dictionary<UInt256, HashSet<ECPoint>> InvalidTransactions = new();
+    public InvalidCache InvalidTransactions;
 
     public StoreCache Snapshot { get; private set; }
     private ECPoint _myPublicKey;
@@ -115,6 +125,7 @@ public sealed partial class ConsensusContext : IDisposable, ISerializable
         _signer = signer;
         this.neoSystem = neoSystem;
         dbftSettings = settings;
+        InvalidTransactions = new InvalidCache(neoSystem.Settings.MemoryPoolMaxTransactions);
 
         if (dbftSettings.IgnoreRecoveryLogs == false)
         {

--- a/plugins/DBFTPlugin/Consensus/ConsensusService.OnMessage.cs
+++ b/plugins/DBFTPlugin/Consensus/ConsensusService.OnMessage.cs
@@ -221,10 +221,10 @@ partial class ConsensusService
                 foreach (UInt256 hash in message.RejectedHashes)
                 {
                     ECPoint pubkey = context.Validators[message.ValidatorIndex];
-                    if (context.InvalidTransactions.TryGetValue(hash, out var hashset))
-                        hashset.Add(pubkey);
+                    if (context.InvalidTransactions.TryGet(hash, out var hashset))
+                        hashset.Value.Add(pubkey);
                     else
-                        context.InvalidTransactions.Add(hash, [pubkey]);
+                        context.InvalidTransactions.Add(new ConsensusContext.UnvalidTxCacheItem(hash, new HashSet<ECPoint> { pubkey }));
                 }
                 break;
         }

--- a/tests/Neo.Plugins.DBFTPlugin.Tests/UT_ConsensusService.cs
+++ b/tests/Neo.Plugins.DBFTPlugin.Tests/UT_ConsensusService.cs
@@ -318,7 +318,7 @@ public class UT_ConsensusService : TestKit
         InvokeConsensusMethod(actor, "OnConsensusPayload", changeViewPayload);
 
         Assert.AreSame(changeViewPayload, context.ChangeViewPayloads[2]);
-        CollectionAssert.Contains(context.InvalidTransactions[rejectedHash].ToArray(), context.Validators[2]);
+        CollectionAssert.Contains(context.InvalidTransactions[rejectedHash].Value.ToArray(), context.Validators[2]);
 
         context.TransactionHashes = null;
         var commit = new Commit


### PR DESCRIPTION
This pull request refactors how invalid transactions are tracked in the consensus process by introducing a custom FIFO cache and updating all related usages. The main goal is to improve memory management and provide a more structured way to handle invalid transactions. The changes affect both the core consensus logic and related tests.

**Invalid transaction tracking improvements:**

* Replaced the `Dictionary<UInt256, HashSet<ECPoint>>` previously used for `InvalidTransactions` with a custom FIFO cache class (`InvalidCache`) that holds `UnvalidTxCacheItem` records, improving memory management and eviction of old invalid entries. [[1]](diffhunk://#diff-0508a82b0fba83f356d31bae2fdd86d324fc3534e7d51c18442de656c84fe433R30-R38) [[2]](diffhunk://#diff-0508a82b0fba83f356d31bae2fdd86d324fc3534e7d51c18442de656c84fe433L53-R63) [[3]](diffhunk://#diff-0508a82b0fba83f356d31bae2fdd86d324fc3534e7d51c18442de656c84fe433R128)
* Updated all usages of `InvalidTransactions` to work with the new cache structure, including accessing the `.Value` property of `UnvalidTxCacheItem` and adding new items in the correct format. [[1]](diffhunk://#diff-e95e82bca993e9c23781bc26001999bf0869e4d2cb3d66d85dd441116efe6dd1L87-R88) [[2]](diffhunk://#diff-c9d04939883f3698dadec88d5dd7c52c7743bfe61fa7efe3b371ae97549c9c67L224-R227) [[3]](diffhunk://#diff-38d81abf98259fc161cf3931bf76b1c3a58c9b529b1da0a1dd0a6b2e53c4ca31L321-R321)

**Codebase maintenance:**

* Added the necessary `using Neo.IO.Caching;` directive to support the new cache implementation.