### PR TITLE
oracle: drop range and hash NeoFS commands

### DIFF
--- a/plugins/OracleService/Protocols/OracleNeoFSProtocol.cs
+++ b/plugins/OracleService/Protocols/OracleNeoFSProtocol.cs
@@ -19,7 +19,6 @@ using System.Security.Cryptography;
 using System.Web;
 using ECPoint = Neo.Cryptography.ECC.ECPoint;
 using Object = Neo.FileStorage.API.Object.Object;
-using Range = Neo.FileStorage.API.Object.Range;
 
 namespace Neo.Plugins.OracleService.Protocols;
 
@@ -87,9 +86,7 @@ class OracleNeoFSProtocol : IOracleProtocol
             return GetPayload(client, objectAddr, tokenSource.Token);
         return ps[2] switch
         {
-            "range" => await GetRangeAsync(client, objectAddr, ps.Skip(3).ToArray(), tokenSource.Token),
             "header" => (OracleResponseCode.Success, await GetHeaderAsync(client, objectAddr, tokenSource.Token)),
-            "hash" => (OracleResponseCode.Success, await GetHashAsync(client, objectAddr, ps.Skip(3).ToArray(), tokenSource.Token)),
             _ => throw new Exception("invalid command")
         };
     }
@@ -113,41 +110,9 @@ class OracleNeoFSProtocol : IOracleProtocol
         return (OracleResponseCode.Success, payload.ToStrictUtf8String());
     }
 
-    private static async Task<(OracleResponseCode, string)> GetRangeAsync(Client client, Address addr, string[] ps, CancellationToken cancellation)
-    {
-        if (ps.Length == 0) throw new FormatException("missing object range (expected 'Offset|Length')");
-        Range range = ParseRange(ps[0]);
-        if (range.Length > OracleResponse.MaxResultSize) return (OracleResponseCode.ResponseTooLarge, "");
-        var res = await client.GetObjectPayloadRangeData(addr, range, options: new CallOptions { Ttl = 2 }, context: cancellation);
-        return (OracleResponseCode.Success, res.ToStrictUtf8String());
-    }
-
     private static async Task<string> GetHeaderAsync(Client client, Address addr, CancellationToken cancellation)
     {
         var obj = await client.GetObjectHeader(addr, options: new CallOptions { Ttl = 2 }, context: cancellation);
         return obj.ToString();
-    }
-
-    private static async Task<string> GetHashAsync(Client client, Address addr, string[] ps, CancellationToken cancellation)
-    {
-        if (ps.Length == 0 || ps[0] == "")
-        {
-            Object obj = await client.GetObjectHeader(addr, options: new CallOptions { Ttl = 2 }, context: cancellation);
-            return $"\"{new UInt256(obj.PayloadChecksum.Sum.ToByteArray())}\"";
-        }
-        Range range = ParseRange(ps[0]);
-        List<byte[]> hashes = await client.GetObjectPayloadRangeHash(addr, new List<Range>() { range }, ChecksumType.Sha256, Array.Empty<byte>(), new CallOptions { Ttl = 2 }, cancellation);
-        if (hashes.Count == 0) throw new Exception("empty response, object range is invalid (expected 'Offset|Length')");
-        return $"\"{new UInt256(hashes[0])}\"";
-    }
-
-    private static Range ParseRange(string s)
-    {
-        string url = HttpUtility.UrlDecode(s);
-        int sepIndex = url.IndexOf('|');
-        if (sepIndex < 0) throw new Exception("object range is invalid (expected 'Offset|Length')");
-        ulong offset = ulong.Parse(url[..sepIndex]);
-        ulong length = ulong.Parse(url[(sepIndex + 1)..]);
-        return new Range() { Offset = offset, Length = length };
     }
 }


### PR DESCRIPTION
GetRangeHash and Range APIs were deprecated in NeoFS protocol starting from version 2.23 (https://github.com/nspcc-dev/neofs-api/releases/tag/v2.23.0). GetRangeHash has no replacement, but it was totally unused and is not very useful for clients (previously it was used internally by NeoFS). Range has a replacement in new Get parameters available from the same API version.

NeoFS node release 0.53.0 has dropped support for GetRangeHash method and calling it now will always lead to error (https://github.com/nspcc-dev/neofs-node/releases/tag/v0.53.0). The same will happen soon to Range request (likely in 0.56.0), so both "commands" will be irrelevant soon and there is no point in keeping support for them.

Originally my idea was to drop them in Huyao hardfork, however Oracle contract performs no URL checks of its own, it all happens in service and services will always reach _some_ consensus and create a transaction, even if their individual results differ. This means we can just drop the code and be done with it.