### PR TITLE
Fix Oracle HTTPS Content-Type NRE and relative redirects

### DIFF
--- a/plugins/OracleService/OracleService.json
+++ b/plugins/OracleService/OracleService.json
@@ -7,7 +7,8 @@
     "AllowedContentTypes": [ "application/json" ],
     "UnhandledExceptionPolicy": "Ignore",
     "Https": {
-      "Timeout": 5000
+      "Timeout": 5000,
+      "MaxRedirects": 2
     },
     "NeoFS": {
       "EndPoint": "http://127.0.0.1:8080",

--- a/plugins/OracleService/OracleSettings.cs
+++ b/plugins/OracleService/OracleSettings.cs
@@ -16,11 +16,23 @@ namespace Neo.Plugins.OracleService;
 
 class HttpsSettings
 {
+    /// <summary>
+    /// Default number of HTTPS redirects to follow after the first request.
+    /// </summary>
+    public const int DefaultMaxRedirects = 2;
+
     public TimeSpan Timeout { get; }
+
+    /// <summary>
+    /// Maximum number of HTTPS redirects to follow. Zero means the first response is used as-is
+    /// (a <c>Location</c> header is not followed). Negative config values are treated as zero.
+    /// </summary>
+    public int MaxRedirects { get; }
 
     public HttpsSettings(IConfigurationSection section)
     {
         Timeout = TimeSpan.FromMilliseconds(section.GetValue("Timeout", 5000));
+        MaxRedirects = Math.Max(0, section.GetValue("MaxRedirects", DefaultMaxRedirects));
     }
 }
 

--- a/plugins/OracleService/Protocols/OracleHttpsProtocol.cs
+++ b/plugins/OracleService/Protocols/OracleHttpsProtocol.cs
@@ -49,7 +49,7 @@ class OracleHttpsProtocol : IOracleProtocol
         HttpResponseMessage message;
         try
         {
-            int redirects = 2;
+            int redirects = OracleSettings.Default.Https.MaxRedirects;
             do
             {
                 if (!OracleSettings.Default.AllowPrivateHost)

--- a/plugins/OracleService/Protocols/OracleHttpsProtocol.cs
+++ b/plugins/OracleService/Protocols/OracleHttpsProtocol.cs
@@ -61,9 +61,13 @@ class OracleHttpsProtocol : IOracleProtocol
                 message = await client.GetAsync(uri, HttpCompletionOption.ResponseContentRead, cancellation);
                 if (message.Headers.Location is not null)
                 {
-                    uri = message.Headers.Location;
-                    if (uri.Scheme != Uri.UriSchemeHttps)
+                    if (!TryResolveHttpsRedirect(uri, message.Headers.Location, out var next))
+                    {
+                        message.Dispose();
                         return (OracleResponseCode.ProtocolNotSupported, null);
+                    }
+                    message.Dispose();
+                    uri = next;
                     message = null;
                 }
             } while (message == null && redirects-- > 0);
@@ -80,7 +84,8 @@ class OracleHttpsProtocol : IOracleProtocol
             return (OracleResponseCode.Forbidden, null);
         if (!message.IsSuccessStatusCode)
             return (OracleResponseCode.Error, message.StatusCode.ToString());
-        if (!OracleSettings.Default.AllowedContentTypes.Contains(message.Content.Headers.ContentType.MediaType))
+        var mediaType = message.Content.Headers.ContentType?.MediaType;
+        if (string.IsNullOrEmpty(mediaType) || !OracleSettings.Default.AllowedContentTypes.Contains(mediaType))
             return (OracleResponseCode.ContentTypeNotSupported, null);
         if (message.Content.Headers.ContentLength.HasValue && message.Content.Headers.ContentLength > OracleResponse.MaxResultSize)
             return (OracleResponseCode.ResponseTooLarge, null);
@@ -108,5 +113,15 @@ class OracleHttpsProtocol : IOracleProtocol
         }
 
         return encoding ?? Encoding.UTF8;
+    }
+
+    /// <summary>
+    /// Resolves an HTTP Location header against the current request URI.
+    /// Relative redirects stay on HTTPS when the current request is HTTPS.
+    /// </summary>
+    internal static bool TryResolveHttpsRedirect(Uri current, Uri location, out Uri next)
+    {
+        next = location.IsAbsoluteUri ? location : new Uri(current, location);
+        return next.IsAbsoluteUri && next.Scheme == Uri.UriSchemeHttps;
     }
 }

--- a/plugins/OracleService/Protocols/OracleHttpsProtocol.cs
+++ b/plugins/OracleService/Protocols/OracleHttpsProtocol.cs
@@ -84,8 +84,7 @@ class OracleHttpsProtocol : IOracleProtocol
             return (OracleResponseCode.Forbidden, null);
         if (!message.IsSuccessStatusCode)
             return (OracleResponseCode.Error, message.StatusCode.ToString());
-        var mediaType = message.Content.Headers.ContentType?.MediaType;
-        if (string.IsNullOrEmpty(mediaType) || !OracleSettings.Default.AllowedContentTypes.Contains(mediaType))
+        if (!IsSupportedContentType(message.Content.Headers, OracleSettings.Default.AllowedContentTypes))
             return (OracleResponseCode.ContentTypeNotSupported, null);
         if (message.Content.Headers.ContentLength.HasValue && message.Content.Headers.ContentLength > OracleResponse.MaxResultSize)
             return (OracleResponseCode.ResponseTooLarge, null);
@@ -104,7 +103,13 @@ class OracleHttpsProtocol : IOracleProtocol
         return (OracleResponseCode.Success, buffer.ToStrictUtf8String(0, read));
     }
 
-    private static Encoding GetEncoding(HttpContentHeaders headers)
+    internal static bool IsSupportedContentType(HttpContentHeaders headers, IEnumerable<string> allowed)
+    {
+        var mediaType = headers.ContentType?.MediaType;
+        return !string.IsNullOrEmpty(mediaType) && allowed.Contains(mediaType);
+    }
+
+    internal static Encoding GetEncoding(HttpContentHeaders headers)
     {
         Encoding encoding = null;
         if ((headers.ContentType != null) && (headers.ContentType.CharSet != null))

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleHttpsProtocol.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleHttpsProtocol.cs
@@ -10,6 +10,8 @@
 // modifications are permitted.
 
 using Neo.Plugins.OracleService.Protocols;
+using System.Net.Http.Headers;
+using System.Text;
 
 namespace Neo.Plugins.OracleService.Tests;
 
@@ -40,5 +42,60 @@ public class UT_OracleHttpsProtocol
         var current = new Uri("https://example.com/oracle");
         var location = new Uri("http://example.com/oracle");
         Assert.IsFalse(OracleHttpsProtocol.TryResolveHttpsRedirect(current, location, out _));
+    }
+
+    [TestMethod]
+    public void TryResolveHttpsRedirect_ResolvesRelativePathWithoutSlash()
+    {
+        var current = new Uri("https://example.com/v1/oracle");
+        var location = new Uri("next", UriKind.Relative);
+        Assert.IsTrue(OracleHttpsProtocol.TryResolveHttpsRedirect(current, location, out var next));
+        Assert.AreEqual("https://example.com/v1/next", next.AbsoluteUri);
+    }
+
+    [TestMethod]
+    public void TryResolveHttpsRedirect_RejectsFtp()
+    {
+        var current = new Uri("https://example.com/oracle");
+        Assert.IsFalse(OracleHttpsProtocol.TryResolveHttpsRedirect(current, new Uri("ftp://example.com/file"), out _));
+    }
+
+    [TestMethod]
+    public void IsSupportedContentType_MissingHeader_IsRejected()
+    {
+        using var message = new HttpResponseMessage();
+        Assert.IsNull(message.Content.Headers.ContentType);
+        Assert.IsFalse(OracleHttpsProtocol.IsSupportedContentType(message.Content.Headers, ["application/json"]));
+    }
+
+    [TestMethod]
+    public void IsSupportedContentType_JsonIsAllowed_XmlIsNot()
+    {
+        using var ok = new HttpResponseMessage();
+        ok.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        using var bad = new HttpResponseMessage();
+        bad.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
+        string[] allowed = ["application/json"];
+        Assert.IsTrue(OracleHttpsProtocol.IsSupportedContentType(ok.Content.Headers, allowed));
+        Assert.IsFalse(OracleHttpsProtocol.IsSupportedContentType(bad.Content.Headers, allowed));
+    }
+
+    [TestMethod]
+    public void GetEncoding_DefaultsToUtf8_WhenCharsetMissing()
+    {
+        using var message = new HttpResponseMessage();
+        Assert.AreEqual(Encoding.UTF8, OracleHttpsProtocol.GetEncoding(message.Content.Headers));
+        message.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        Assert.AreEqual(Encoding.UTF8, OracleHttpsProtocol.GetEncoding(message.Content.Headers));
+    }
+
+    [TestMethod]
+    public void GetEncoding_UsesDeclaredCharset()
+    {
+        using var message = new HttpResponseMessage();
+        message.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" };
+        Assert.AreEqual(Encoding.UTF8, OracleHttpsProtocol.GetEncoding(message.Content.Headers));
+        message.Content.Headers.ContentType.CharSet = "utf-16";
+        Assert.AreEqual(Encoding.Unicode, OracleHttpsProtocol.GetEncoding(message.Content.Headers));
     }
 }

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleHttpsProtocol.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleHttpsProtocol.cs
@@ -1,0 +1,44 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_OracleHttpsProtocol.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Neo.Plugins.OracleService.Protocols;
+
+namespace Neo.Plugins.OracleService.Tests;
+
+[TestClass]
+public class UT_OracleHttpsProtocol
+{
+    [TestMethod]
+    public void TryResolveHttpsRedirect_KeepsAbsoluteHttps()
+    {
+        var current = new Uri("https://example.com/oracle");
+        var location = new Uri("https://cdn.example.com/data.json");
+        Assert.IsTrue(OracleHttpsProtocol.TryResolveHttpsRedirect(current, location, out var next));
+        Assert.AreEqual(location, next);
+    }
+
+    [TestMethod]
+    public void TryResolveHttpsRedirect_ResolvesRelativeAgainstCurrent()
+    {
+        var current = new Uri("https://example.com/v1/oracle");
+        var location = new Uri("/v2/oracle", UriKind.Relative);
+        Assert.IsTrue(OracleHttpsProtocol.TryResolveHttpsRedirect(current, location, out var next));
+        Assert.AreEqual("https://example.com/v2/oracle", next.AbsoluteUri);
+    }
+
+    [TestMethod]
+    public void TryResolveHttpsRedirect_RejectsHttp()
+    {
+        var current = new Uri("https://example.com/oracle");
+        var location = new Uri("http://example.com/oracle");
+        Assert.IsFalse(OracleHttpsProtocol.TryResolveHttpsRedirect(current, location, out _));
+    }
+}

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleHttpsProtocol.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleHttpsProtocol.cs
@@ -9,6 +9,7 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Microsoft.Extensions.Configuration;
 using Neo.Plugins.OracleService.Protocols;
 using System.Net.Http.Headers;
 using System.Text;
@@ -97,5 +98,36 @@ public class UT_OracleHttpsProtocol
         Assert.AreEqual(Encoding.UTF8, OracleHttpsProtocol.GetEncoding(message.Content.Headers));
         message.Content.Headers.ContentType.CharSet = "utf-16";
         Assert.AreEqual(Encoding.Unicode, OracleHttpsProtocol.GetEncoding(message.Content.Headers));
+    }
+
+    [TestMethod]
+    public void HttpsSettings_MaxRedirects_DefaultsToTwo()
+    {
+        var https = new HttpsSettings(EmptySection());
+        Assert.AreEqual(HttpsSettings.DefaultMaxRedirects, https.MaxRedirects);
+        Assert.AreEqual(2, https.MaxRedirects);
+    }
+
+    [TestMethod]
+    public void HttpsSettings_MaxRedirects_ReadsFromConfig()
+    {
+        var https = new HttpsSettings(Section(("MaxRedirects", "5")));
+        Assert.AreEqual(5, https.MaxRedirects);
+    }
+
+    [TestMethod]
+    public void HttpsSettings_MaxRedirects_ClampsNegativeToZero()
+    {
+        var https = new HttpsSettings(Section(("MaxRedirects", "-3")));
+        Assert.AreEqual(0, https.MaxRedirects);
+    }
+
+    private static IConfigurationSection EmptySection()
+        => new ConfigurationBuilder().AddInMemoryCollection().Build().GetSection("Https");
+
+    private static IConfigurationSection Section(params (string Key, string Value)[] values)
+    {
+        var data = values.ToDictionary(p => "Https:" + p.Key, p => p.Value);
+        return new ConfigurationBuilder().AddInMemoryCollection(data!).Build().GetSection("Https");
     }
 }


### PR DESCRIPTION
## Summary

`OracleHttpsProtocol.ProcessAsync` crashed with `NullReferenceException` when the HTTP response had no `Content-Type` header (the null check sat *after* the try/catch). It also treated relative `Location` values as non-HTTPS, so in-site HTTPS redirects failed.

## Changes

- Treat a missing `Content-Type` / media type as `ContentTypeNotSupported`.
- Resolve relative redirect URIs against the current request URI; still reject non-HTTPS.
- Dispose the redirect response before following `Location`.
- `Https.MaxRedirects` in `OracleService.json` (default **2**, same as the old hardcoded limit). Negative values clamp to 0.

## Tests

- Absolute HTTPS redirect kept as-is; relative path resolved; HTTP/FTP rejected
- Missing `Content-Type` rejected; `application/json` allowed; `text/html` rejected
- Encoding defaults to UTF-8; declared charset is honored
- `MaxRedirects` default, config value, and negative clamp

Independent of other neo-node branches.
