### PR TITLE
Return empty array from getcandidates when the VM stack is empty

### DIFF
--- a/plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/plugins/RpcServer/RpcServer.Blockchain.cs
@@ -590,7 +590,7 @@ partial class RpcServer
                 ?? throw new RpcException(RpcError.InternalServerError.WithData("Can't get next block validators."));
             return FormatCandidates(resultstack, validators);
         }
-        catch (Exception ex) when (ex is not RpcException)
+        catch
         {
             throw new RpcException(RpcError.InternalServerError.WithData("Can't get next block validators"));
         }

--- a/plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/plugins/RpcServer/RpcServer.Blockchain.cs
@@ -581,37 +581,51 @@ partial class RpcServer
             throw new RpcException(RpcError.InternalServerError.WithData("Can't get candidates."));
         }
 
-        JObject json = new();
         try
         {
-            if (resultstack.Length > 0)
-            {
-                JArray jArray = new();
-                var validators = NativeContract.NEO.GetNextBlockValidators(snapshot, system.Settings.ValidatorsCount)
-                    ?? throw new RpcException(RpcError.InternalServerError.WithData("Can't get next block validators."));
+            if (resultstack.Length == 0)
+                return FormatCandidates(resultstack, []);
 
-                foreach (var item in resultstack)
-                {
-                    var value = (Array)item;
-                    foreach (Struct ele in value)
-                    {
-                        var publickey = ECPoint.DecodePoint(ele[0].GetSpan(), ECCurve.Secp256r1);
-                        json["publickey"] = publickey.ToString();
-                        json["votes"] = ele[1].GetInteger().ToString();
-                        json["active"] = validators.Contains(publickey);
-                        jArray.Add(json);
-                        json = new();
-                    }
-                    return jArray;
-                }
-            }
+            var validators = NativeContract.NEO.GetNextBlockValidators(snapshot, system.Settings.ValidatorsCount)
+                ?? throw new RpcException(RpcError.InternalServerError.WithData("Can't get next block validators."));
+            return FormatCandidates(resultstack, validators);
+        }
+        catch (RpcException)
+        {
+            throw;
         }
         catch
         {
             throw new RpcException(RpcError.InternalServerError.WithData("Can't get next block validators"));
         }
+    }
 
-        return new JArray();
+    /// <summary>
+    /// Builds the getcandidates JSON array. An empty VM stack yields <c>[]</c>, not <c>{}</c>.
+    /// </summary>
+    internal static JToken FormatCandidates(StackItem[] resultstack, IReadOnlyCollection<ECPoint> validators)
+    {
+        var jArray = new JArray();
+        if (resultstack.Length == 0)
+            return jArray;
+
+        foreach (var item in resultstack)
+        {
+            var value = (Array)item;
+            foreach (Struct ele in value)
+            {
+                var publickey = ECPoint.DecodePoint(ele[0].GetSpan(), ECCurve.Secp256r1);
+                jArray.Add(new JObject
+                {
+                    ["publickey"] = publickey.ToString(),
+                    ["votes"] = ele[1].GetInteger().ToString(),
+                    ["active"] = validators.Contains(publickey),
+                });
+            }
+            return jArray;
+        }
+
+        return jArray;
     }
 
     /// <summary>

--- a/plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/plugins/RpcServer/RpcServer.Blockchain.cs
@@ -590,11 +590,7 @@ partial class RpcServer
                 ?? throw new RpcException(RpcError.InternalServerError.WithData("Can't get next block validators."));
             return FormatCandidates(resultstack, validators);
         }
-        catch (RpcException)
-        {
-            throw;
-        }
-        catch
+        catch (Exception ex) when (ex is not RpcException)
         {
             throw new RpcException(RpcError.InternalServerError.WithData("Can't get next block validators"));
         }

--- a/plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/plugins/RpcServer/RpcServer.Blockchain.cs
@@ -587,7 +587,7 @@ partial class RpcServer
                 return FormatCandidates(resultstack, []);
 
             var validators = NativeContract.NEO.GetNextBlockValidators(snapshot, system.Settings.ValidatorsCount)
-                ?? throw new RpcException(RpcError.InternalServerError.WithData("Can't get next block validators."));
+                ?? throw new Exception();
             return FormatCandidates(resultstack, validators);
         }
         catch

--- a/plugins/RpcServer/RpcServer.Blockchain.cs
+++ b/plugins/RpcServer/RpcServer.Blockchain.cs
@@ -611,7 +611,7 @@ partial class RpcServer
             throw new RpcException(RpcError.InternalServerError.WithData("Can't get next block validators"));
         }
 
-        return json;
+        return new JArray();
     }
 
     /// <summary>

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Blockchain.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Blockchain.cs
@@ -19,7 +19,9 @@ using Neo.Network.P2P.Payloads;
 using Neo.Plugins.RpcServer.Model;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
+using Neo.VM.Types;
 using static Neo.SmartContract.Native.NeoToken;
+using Array = Neo.VM.Types.Array;
 
 namespace Neo.Plugins.RpcServer.Tests;
 
@@ -612,6 +614,52 @@ public partial class UT_RpcServer
             json.Add(item);
         }
         Assert.AreEqual(json.ToString(), result.ToString());
+        Assert.IsInstanceOfType<JArray>(result);
+    }
+
+    [TestMethod]
+    public void TestGetCandidates_EmptyStack_ReturnsArray()
+    {
+        var result = Neo.Plugins.RpcServer.RpcServer.FormatCandidates([], []);
+        Assert.IsInstanceOfType<JArray>(result);
+        Assert.IsEmpty((JArray)result);
+        Assert.AreEqual("[]", result.ToString());
+    }
+
+    [TestMethod]
+    public void TestGetCandidates_EmptyInnerArray_ReturnsArray()
+    {
+        var result = Neo.Plugins.RpcServer.RpcServer.FormatCandidates([new Array()], []);
+        Assert.IsInstanceOfType<JArray>(result);
+        Assert.IsEmpty((JArray)result);
+    }
+
+    [TestMethod]
+    public void TestGetCandidates_FormatsVotesAsStringAndActiveFlag()
+    {
+        var pubkey = TestProtocolSettings.Default.StandbyCommittee[0];
+        var other = TestProtocolSettings.Default.StandbyCommittee[1];
+        var stack = new Array(
+        [
+            new Struct([pubkey.EncodePoint(true), 12_345]),
+            new Struct([other.EncodePoint(true), 0]),
+        ]);
+
+        var result = (JArray)Neo.Plugins.RpcServer.RpcServer.FormatCandidates([stack], [pubkey]);
+        Assert.HasCount(2, result);
+        Assert.AreEqual(pubkey.ToString(), result[0]!["publickey"]!.AsString());
+        Assert.AreEqual("12345", result[0]!["votes"]!.AsString());
+        Assert.IsTrue(result[0]!["active"]!.AsBoolean());
+        Assert.AreEqual(other.ToString(), result[1]!["publickey"]!.AsString());
+        Assert.AreEqual("0", result[1]!["votes"]!.AsString());
+        Assert.IsFalse(result[1]!["active"]!.AsBoolean());
+    }
+
+    [TestMethod]
+    public void TestGetCandidates_InvalidStack_Throws()
+    {
+        Assert.ThrowsExactly<InvalidCastException>(() =>
+            Neo.Plugins.RpcServer.RpcServer.FormatCandidates([StackItem.Null], []));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

`getcandidates` is documented as returning a JSON array. When `ApplicationEngine.ResultStack` was empty, the method returned a new `JObject` (`{}`). That is not an array and breaks clients.

## Change

Return `new JArray()` on the empty-stack path. Candidate JSON is built by `FormatCandidates` so the empty-stack path is unit-tested.

## Tests

- Empty VM stack → `[]`
- Empty inner array → `[]`
- Votes as string, `active` true/false
- Invalid stack item throws
- Existing populated `getcandidates` still matches native results

Independent of other neo-node branches.
