### PR TITLE
Report neo-node version from getversion (neo-node#983)

### DIFF
--- a/plugins/RpcServer/RpcServer.Node.cs
+++ b/plugins/RpcServer/RpcServer.Node.cs
@@ -123,8 +123,7 @@ partial class RpcServer
     ///   "result": {
     ///     "tcpport": 10333, // The TCP port,
     ///     "nonce": 1, // The nonce,
-    ///     "useragent": "The Neo library user agent",
-    ///     "version": "The neo-node / RpcServer assembly version",
+    ///     "useragent": "/Neo:3.10.2/", // Node assembly version in the existing useragent field,
     ///     "rpc": {
     ///       "maxiteratorresultitems": 100, // The maximum number of items in the iterator result,
     ///       "sessionenabled": false // Whether session is enabled,
@@ -153,9 +152,8 @@ partial class RpcServer
         JObject json = new();
         json["tcpport"] = localNode.ListenerTcpPort;
         json["nonce"] = LocalNode.Nonce;
-        json["useragent"] = LocalNode.UserAgent;
-        // UserAgent comes from Neo.dll; version is this node/plugin assembly (neo-node#983).
-        json["version"] = typeof(RpcServer).Assembly.GetName().Version?.ToString(3);
+        var nodeVersion = typeof(RpcServer).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+        json["useragent"] = UserAgentWithVersion(LocalNode.UserAgent, nodeVersion);
         // rpc settings
         JObject rpc = new();
         rpc["maxiteratorresultitems"] = settings.MaxIteratorResultItems;
@@ -184,6 +182,19 @@ partial class RpcServer
         json["rpc"] = rpc;
         json["protocol"] = protocol;
         return json;
+    }
+
+    /// <summary>
+    /// Keeps the P2P useragent product name and replaces the version with <paramref name="version"/>.
+    /// <c>/Neo:3.10.1/</c> plus <c>3.10.2</c> becomes <c>/Neo:3.10.2/</c>.
+    /// </summary>
+    internal static string UserAgentWithVersion(string userAgent, string version)
+    {
+        var colon = userAgent.IndexOf(':');
+        var slash = userAgent.LastIndexOf('/');
+        if (colon >= 0 && slash > colon)
+            return string.Concat(userAgent.AsSpan(0, colon + 1), version, userAgent.AsSpan(slash));
+        return $"/Neo:{version}/";
     }
 
     /// <summary>

--- a/plugins/RpcServer/RpcServer.Node.cs
+++ b/plugins/RpcServer/RpcServer.Node.cs
@@ -123,7 +123,8 @@ partial class RpcServer
     ///   "result": {
     ///     "tcpport": 10333, // The TCP port,
     ///     "nonce": 1, // The nonce,
-    ///     "useragent": "The user agent",
+    ///     "useragent": "The Neo library user agent",
+    ///     "version": "The neo-node / RpcServer assembly version",
     ///     "rpc": {
     ///       "maxiteratorresultitems": 100, // The maximum number of items in the iterator result,
     ///       "sessionenabled": false // Whether session is enabled,
@@ -153,6 +154,8 @@ partial class RpcServer
         json["tcpport"] = localNode.ListenerTcpPort;
         json["nonce"] = LocalNode.Nonce;
         json["useragent"] = LocalNode.UserAgent;
+        // UserAgent comes from Neo.dll; version is this node/plugin assembly (neo-node#983).
+        json["version"] = typeof(RpcServer).Assembly.GetName().Version?.ToString(3);
         // rpc settings
         JObject rpc = new();
         rpc["maxiteratorresultitems"] = settings.MaxIteratorResultItems;

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
@@ -119,6 +119,15 @@ partial class UT_RpcServer
         Assert.IsTrue(json.ContainsProperty("useragent"));
         Assert.IsTrue(json.ContainsProperty("version"));
         Assert.AreEqual(_rpcServer.GetType().Assembly.GetName().Version?.ToString(3), json["version"]!.AsString());
+        Assert.IsFalse(string.IsNullOrEmpty(json["version"]!.AsString()));
+        Assert.HasCount(3, json["version"]!.AsString().Split('.'));
+
+        Assert.IsTrue(json.ContainsProperty("rpc"));
+        var rpc = (JObject)json["rpc"]!;
+        Assert.IsTrue(rpc.ContainsProperty("maxiteratorresultitems"));
+        Assert.IsTrue(rpc.ContainsProperty("sessionenabled"));
+        Assert.AreEqual(_rpcServerSettings.MaxIteratorResultItems, rpc["maxiteratorresultitems"]!.AsNumber());
+        Assert.AreEqual(_rpcServerSettings.SessionEnabled, rpc["sessionenabled"]!.AsBoolean());
 
         Assert.IsTrue(json.ContainsProperty("protocol"));
         var protocol = (JObject)json["protocol"];
@@ -132,6 +141,17 @@ partial class UT_RpcServer
         Assert.IsTrue(protocol.ContainsProperty("memorypoolmaxtransactions"));
         Assert.IsTrue(protocol.ContainsProperty("standbycommittee"));
         Assert.IsTrue(protocol.ContainsProperty("seedlist"));
+    }
+
+    [TestMethod]
+    public void TestGetVersion_VersionIsNodeAssemblyNotUserAgent()
+    {
+        var json = (JObject)_rpcServer.GetVersion();
+        var version = json["version"]!.AsString();
+        var useragent = json["useragent"]!.AsString();
+        Assert.AreEqual(_rpcServer.GetType().Assembly.GetName().Version?.ToString(3), version);
+        Assert.IsFalse(string.IsNullOrEmpty(useragent));
+        Assert.AreNotEqual(version, useragent);
     }
 
     [TestMethod]

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
@@ -117,10 +117,10 @@ partial class UT_RpcServer
         Assert.IsTrue(json.ContainsProperty("tcpport"));
         Assert.IsTrue(json.ContainsProperty("nonce"));
         Assert.IsTrue(json.ContainsProperty("useragent"));
-        Assert.IsTrue(json.ContainsProperty("version"));
-        Assert.AreEqual(_rpcServer.GetType().Assembly.GetName().Version?.ToString(3), json["version"]!.AsString());
-        Assert.IsFalse(string.IsNullOrEmpty(json["version"]!.AsString()));
-        Assert.HasCount(3, json["version"]!.AsString().Split('.'));
+        Assert.IsFalse(json.ContainsProperty("version"));
+        var nodeVersion = _rpcServer.GetType().Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+        Assert.AreEqual(RpcServer.UserAgentWithVersion(LocalNode.UserAgent, nodeVersion), json["useragent"]!.AsString());
+        Assert.Contains($":{nodeVersion}/", json["useragent"]!.AsString());
 
         Assert.IsTrue(json.ContainsProperty("rpc"));
         var rpc = (JObject)json["rpc"]!;
@@ -144,14 +144,12 @@ partial class UT_RpcServer
     }
 
     [TestMethod]
-    public void TestGetVersion_VersionIsNodeAssemblyNotUserAgent()
+    public void TestUserAgentWithVersion_ReplacesVersionKeepsProduct()
     {
-        var json = (JObject)_rpcServer.GetVersion();
-        var version = json["version"]!.AsString();
-        var useragent = json["useragent"]!.AsString();
-        Assert.AreEqual(_rpcServer.GetType().Assembly.GetName().Version?.ToString(3), version);
-        Assert.IsFalse(string.IsNullOrEmpty(useragent));
-        Assert.AreNotEqual(version, useragent);
+        Assert.AreEqual("/Neo:3.10.2/", RpcServer.UserAgentWithVersion("/Neo:3.10.1/", "3.10.2"));
+        Assert.AreEqual("/MyNode:3.10.2/", RpcServer.UserAgentWithVersion("/MyNode:1.0.0/", "3.10.2"));
+        Assert.AreEqual("/Neo:3.10.2/", RpcServer.UserAgentWithVersion("not-a-ua", "3.10.2"));
+        Assert.AreEqual("/Neo:3.10.2/", RpcServer.UserAgentWithVersion(string.Empty, "3.10.2"));
     }
 
     [TestMethod]

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Node.cs
@@ -117,6 +117,8 @@ partial class UT_RpcServer
         Assert.IsTrue(json.ContainsProperty("tcpport"));
         Assert.IsTrue(json.ContainsProperty("nonce"));
         Assert.IsTrue(json.ContainsProperty("useragent"));
+        Assert.IsTrue(json.ContainsProperty("version"));
+        Assert.AreEqual(_rpcServer.GetType().Assembly.GetName().Version?.ToString(3), json["version"]!.AsString());
 
         Assert.IsTrue(json.ContainsProperty("protocol"));
         var protocol = (JObject)json["protocol"];


### PR DESCRIPTION
## Summary

`getversion` reported `useragent` from `LocalNode.UserAgent`, which is the **Neo.dll** assembly, not neo-cli / RpcServer. After a node bump (e.g. 3.9.2 / 3.10.2) the RPC still advertised the older library version.

Fixes #983

## Change

No new JSON field. The existing `useragent` string keeps the product name and uses the RpcServer assembly version (`VersionPrefix`), so `/Neo:3.10.1/` becomes `/Neo:3.10.2/`. Malformed useragents fall back to `/Neo:{version}/`.

## Tests

- `getversion` has no `version` property
- `useragent` contains the RpcServer 3-part assembly version
- `UserAgentWithVersion` keeps the product name and replaces the version
- `rpc.maxiteratorresultitems` / `rpc.sessionenabled` match settings

Independent of other neo-node branches.