### PR TITLE
Use VMInstruction.ToString for parse script listings

### DIFF
--- a/src/Neo.CLI/CLI/MainService.Tools.cs
+++ b/src/Neo.CLI/CLI/MainService.Tools.cs
@@ -409,7 +409,7 @@ partial class MainService
     /// <summary>
     /// Base64 Smart Contract Script Analysis
     /// input: DARkYXRhAgBlzR0MFPdcrAXPVptVduMEs2lf1jQjxKIKDBT3XKwFz1abVXbjBLNpX9Y0I8SiChTAHwwIdHJhbnNmZXIMFKNSbimM12LkFYX/8KGvm2ttFxulQWJ9W1I=
-    /// output (VMInstruction.ToString, with a line number prefix):
+    /// output (VMInstruction.ToString, with an L-prefix padded to at least 4 digits):
     /// L0000:0000 PUSHDATA1 64617461 // data
     /// L0001:0006 PUSHINT32 500000000
     /// L0002:000B PUSHDATA1 0AA2C42334D65F69B304E376559B56CF05AC5CF7
@@ -420,17 +420,7 @@ partial class MainService
         try
         {
             var bytes = Convert.FromBase64String(base64);
-            var sb = new StringBuilder();
-            var line = 0;
-
-            foreach (var instruct in new VMInstruction(bytes))
-            {
-                sb.AppendFormat("L{0:D04}:{1}", line, instruct);
-                sb.AppendLine();
-                line++;
-            }
-
-            return sb.ToString();
+            return VMInstruction.FormatListing(bytes);
         }
         catch
         {

--- a/src/Neo.CLI/CLI/MainService.Tools.cs
+++ b/src/Neo.CLI/CLI/MainService.Tools.cs
@@ -409,17 +409,10 @@ partial class MainService
     /// <summary>
     /// Base64 Smart Contract Script Analysis
     /// input: DARkYXRhAgBlzR0MFPdcrAXPVptVduMEs2lf1jQjxKIKDBT3XKwFz1abVXbjBLNpX9Y0I8SiChTAHwwIdHJhbnNmZXIMFKNSbimM12LkFYX/8KGvm2ttFxulQWJ9W1I=
-    /// output:
-    /// PUSHDATA1 data
-    /// PUSHINT32 500000000
-    /// PUSHDATA1 0x0aa2c42334d65f69b304e376559b56cf05ac5cf7
-    /// PUSHDATA1 0x0aa2c42334d65f69b304e376559b56cf05ac5cf7
-    /// PUSH4
-    /// PACK
-    /// PUSH15
-    /// PUSHDATA1 transfer
-    /// PUSHDATA1 0xa51b176d6b9bafa1f0ff8515e462d78c296e52a3
-    /// SYSCALL System.Contract.Call
+    /// output (VMInstruction.ToString, with a line number prefix):
+    /// L0000:0000 PUSHDATA1 64617461 // data
+    /// L0001:0006 PUSHINT32 500000000
+    /// L0002:000B PUSHDATA1 0AA2C42334D65F69B304E376559B56CF05AC5CF7
     /// </summary>
     [ParseFunction("Base64 Smart Contract Script Analysis")]
     private string? ScriptsToOpCode(string base64)
@@ -432,10 +425,8 @@ partial class MainService
 
             foreach (var instruct in new VMInstruction(bytes))
             {
-                if (instruct.OperandSize == 0)
-                    sb.AppendFormat("L{0:D04}:{1:X04} {2}{3}", line, instruct.Position, instruct.OpCode, Environment.NewLine);
-                else
-                    sb.AppendFormat("L{0:D04}:{1:X04} {2,-10}{3}{4}", line, instruct.Position, instruct.OpCode, instruct.DecodeOperand(), Environment.NewLine);
+                sb.AppendFormat("L{0:D04}:{1}", line, instruct);
+                sb.AppendLine();
                 line++;
             }
 

--- a/src/Neo.CLI/Neo.CLI.csproj
+++ b/src/Neo.CLI/Neo.CLI.csproj
@@ -21,6 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Neo.CLI.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="neo.ico" />
   </ItemGroup>
 

--- a/src/Neo.CLI/Tools/VMInstruction.cs
+++ b/src/Neo.CLI/Tools/VMInstruction.cs
@@ -100,10 +100,42 @@ internal sealed class VMInstruction : IEnumerable<VMInstruction>
 
     public override string ToString()
     {
+        var posWidth = HexWidth(_script.Length);
         if (OperandSize == 0)
-            return string.Format("{0:X04} {1}", Position, OpCode);
-        return string.Format("{0:X04} {1,-10}{2}", Position, OpCode, DecodeOperand());
+            return string.Format($"{{0:X{posWidth}}} {{1}}", Position, OpCode);
+        return string.Format($"{{0:X{posWidth}}} {{1,-10}}{{2}}", Position, OpCode, DecodeOperand());
     }
+
+    /// <summary>
+    /// Lists instructions as <c>L0000:0000 NOP</c>. The L-prefix width is at least 4 digits
+    /// and grows with the script size / instruction count.
+    /// </summary>
+    internal static string FormatListing(ReadOnlyMemory<byte> script)
+    {
+        var rows = new List<VMInstruction>();
+        foreach (var instruct in new VMInstruction(script))
+            rows.Add(instruct);
+
+        var lastIndex = Math.Max(0, rows.Count - 1);
+        var width = DecimalWidth(Math.Max(lastIndex, script.Length));
+        var sb = new StringBuilder();
+        for (var i = 0; i < rows.Count; i++)
+        {
+            sb.Append('L');
+            sb.Append(i.ToString($"D{width}", CultureInfo.InvariantCulture));
+            sb.Append(':');
+            sb.Append(rows[i]);
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    internal static int DecimalWidth(int value)
+        => Math.Max(4, Math.Max(0, value).ToString(CultureInfo.InvariantCulture).Length);
+
+    internal static int HexWidth(int length)
+        => Math.Max(4, Math.Max(0, length == 0 ? 0 : length - 1).ToString("X").Length);
 
     public T AsToken<T>(uint index = 0)
         where T : unmanaged

--- a/src/Neo.CLI/Tools/VMInstruction.cs
+++ b/src/Neo.CLI/Tools/VMInstruction.cs
@@ -9,11 +9,13 @@
 // Redistribution and use in source and binary forms with or without
 // modifications are permitted.
 
+using Neo.Cryptography.ECC;
 using Neo.SmartContract;
 using Neo.VM;
 using System.Buffers.Binary;
 using System.Collections;
 using System.Diagnostics;
+using System.Globalization;
 using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -157,17 +159,100 @@ internal sealed class VMInstruction : IEnumerable<VMInstruction>
             OpCode.LDARG or
             OpCode.STARG or
             OpCode.INITSSLOT => $"{AsToken<byte>()}",
-            OpCode.PUSHINT8 => $"{AsToken<sbyte>()}",
-            OpCode.PUSHINT16 => $"{AsToken<short>()}",
-            OpCode.PUSHINT32 => $"{AsToken<int>()}",
-            OpCode.PUSHINT64 => $"{AsToken<long>()}",
+            OpCode.PUSHINT8 => FormatInteger(AsToken<sbyte>()),
+            OpCode.PUSHINT16 => FormatInteger(AsToken<short>()),
+            OpCode.PUSHINT32 => FormatInteger(AsToken<int>()),
+            OpCode.PUSHINT64 => FormatInteger(AsToken<long>()),
             OpCode.PUSHINT128 or
             OpCode.PUSHINT256 => $"{new BigInteger(operand)}",
             OpCode.SYSCALL => $"[{ApplicationEngine.Services[Unsafe.As<byte, uint>(ref operand[0])].Name}]",
             OpCode.PUSHDATA1 or
             OpCode.PUSHDATA2 or
-            OpCode.PUSHDATA4 => readable ? $"{Convert.ToHexString(operand)} // {asStr}" : Convert.ToHexString(operand),
-            _ => readable ? $"\"{asStr}\"" : $"{Convert.ToHexString(operand)}",
+            OpCode.PUSHDATA4 => FormatPushData(operand),
+            _ => IsReadableText(asStr) ? $"\"{asStr}\"" : $"{Convert.ToHexString(operand)}",
         };
+    }
+
+    private static string FormatPushData(byte[] operand)
+    {
+        var hex = Convert.ToHexString(operand);
+        var asStr = Encoding.UTF8.GetString(operand);
+        if (IsReadableText(asStr))
+            return $"{hex} // {asStr}";
+
+        if (TryDecodeEcPoint(operand, out var point))
+            return $"{hex} // {point}";
+
+        if (operand.Length == UInt160.Length)
+            return $"{hex} // {new UInt160(operand)}";
+
+        if (operand.Length == UInt256.Length)
+            return $"{hex} // {new UInt256(operand)}";
+
+        if (operand.Length == 4 && TryFormatUnixTimestamp(BinaryPrimitives.ReadUInt32LittleEndian(operand), out var ts32))
+            return $"{hex} // {ts32}";
+
+        if (operand.Length == 8 && TryFormatUnixTimestamp(BinaryPrimitives.ReadInt64LittleEndian(operand), out var ts64))
+            return $"{hex} // {ts64}";
+
+        return hex;
+    }
+
+    private static string FormatInteger(long value)
+        => TryFormatUnixTimestamp(value, out var ts) ? $"{value} // {ts}" : value.ToString(CultureInfo.InvariantCulture);
+
+    private static bool IsReadableText(string value)
+        => value.Length > 0 && value.Any(char.IsAsciiLetter) && value.All(static c => char.IsAscii(c) && !char.IsControl(c));
+
+    private static bool TryDecodeEcPoint(byte[] operand, out ECPoint point)
+    {
+        point = null!;
+        if (operand.Length is not (33 or 65))
+            return false;
+        if (operand[0] is not (0x02 or 0x03 or 0x04))
+            return false;
+        try
+        {
+            point = ECPoint.DecodePoint(operand, ECCurve.Secp256r1);
+            return true;
+        }
+        catch (FormatException)
+        {
+            try
+            {
+                point = ECPoint.DecodePoint(operand, ECCurve.Secp256k1);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Unix seconds in 2000–2100, or unix milliseconds in that same window.
+    /// </summary>
+    private static bool TryFormatUnixTimestamp(long value, out string text)
+    {
+        const long UnixSeconds2000 = 946_684_800;
+        const long UnixSeconds2100 = 4_102_444_800;
+        const long UnixMilliseconds2000 = 946_684_800_000;
+        const long UnixMilliseconds2100 = 4_102_444_800_000;
+
+        if (value >= UnixSeconds2000 && value <= UnixSeconds2100)
+        {
+            text = DateTimeOffset.FromUnixTimeSeconds(value).UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        if (value >= UnixMilliseconds2000 && value <= UnixMilliseconds2100)
+        {
+            text = DateTimeOffset.FromUnixTimeMilliseconds(value).UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        text = null!;
+        return false;
     }
 }

--- a/src/Neo.CLI/Tools/VMInstruction.cs
+++ b/src/Neo.CLI/Tools/VMInstruction.cs
@@ -168,7 +168,9 @@ internal sealed class VMInstruction : IEnumerable<VMInstruction>
             OpCode.PUSHDATA1 or
             OpCode.PUSHDATA2 or
             OpCode.PUSHDATA4 => FormatPushData(operand),
-            _ => TryGetReadableText(operand, out var text) ? $"\"{text}\"" : $"{Convert.ToHexString(operand)}",
+            _ => TryGetReadableText(operand, out var text)
+                ? $"\"{text}\""
+                : $"{Convert.ToHexString(operand)} // blob {operand.Length} bytes",
         };
     }
 
@@ -193,14 +195,15 @@ internal sealed class VMInstruction : IEnumerable<VMInstruction>
         if (operand.Length == 8 && TryFormatUnixTimestamp(BinaryPrimitives.ReadInt64LittleEndian(operand), out var ts64))
             return $"{hex} // {ts64}";
 
-        return hex;
+        return $"{hex} // blob {operand.Length} bytes";
     }
 
     private static string FormatInteger(long value)
         => TryFormatUnixTimestamp(value, out var ts) ? $"{value} // {ts}" : value.ToString(CultureInfo.InvariantCulture);
 
     /// <summary>
-    /// Strict UTF-8 whose runes are all printable (not control characters).
+    /// Strict UTF-8 with at least one non-control rune. Control runes are escaped
+    /// (<c>\n</c>, <c>\r</c>, <c>\t</c>, <c>\xNN</c>) so they are not written as raw output.
     /// Invalid sequences are rejected; <see cref="Encoding.UTF8"/> replacement is not used.
     /// </summary>
     private static bool TryGetReadableText(ReadOnlySpan<byte> utf8, out string text)
@@ -209,18 +212,36 @@ internal sealed class VMInstruction : IEnumerable<VMInstruction>
         if (utf8.IsEmpty || !Utf8.IsValid(utf8))
             return false;
 
-        text = Encoding.UTF8.GetString(utf8);
-        foreach (var rune in text.EnumerateRunes())
+        var decoded = Encoding.UTF8.GetString(utf8);
+        var hasGraphic = false;
+        var sb = new StringBuilder(decoded.Length);
+        foreach (var rune in decoded.EnumerateRunes())
         {
-            if (Rune.IsControl(rune))
+            if (Rune.IsControl(rune) || rune.Value == 0x7F)
+                sb.Append(EscapeControlRune(rune));
+            else
             {
-                text = null!;
-                return false;
+                hasGraphic = true;
+                sb.Append(rune);
             }
         }
 
+        if (!hasGraphic)
+            return false;
+
+        text = sb.ToString();
         return true;
     }
+
+    private static string EscapeControlRune(Rune rune)
+        => rune.Value switch
+        {
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            '\0' => "\\0",
+            _ => rune.Value <= 0xFF ? $"\\x{rune.Value:X2}" : $"\\u{rune.Value:X4}",
+        };
 
     private static bool TryDecodeEcPoint(byte[] operand, out ECPoint point)
     {

--- a/src/Neo.CLI/Tools/VMInstruction.cs
+++ b/src/Neo.CLI/Tools/VMInstruction.cs
@@ -20,6 +20,7 @@ using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Unicode;
 
 namespace Neo.CLI;
 
@@ -121,8 +122,6 @@ internal sealed class VMInstruction : IEnumerable<VMInstruction>
     public string DecodeOperand()
     {
         var operand = Operand[OperandPrefixSize..].ToArray();
-        var asStr = Encoding.UTF8.GetString(operand);
-        var readable = asStr.All(char.IsAsciiLetterOrDigit);
 
         return OpCode switch
         {
@@ -169,16 +168,15 @@ internal sealed class VMInstruction : IEnumerable<VMInstruction>
             OpCode.PUSHDATA1 or
             OpCode.PUSHDATA2 or
             OpCode.PUSHDATA4 => FormatPushData(operand),
-            _ => IsReadableText(asStr) ? $"\"{asStr}\"" : $"{Convert.ToHexString(operand)}",
+            _ => TryGetReadableText(operand, out var text) ? $"\"{text}\"" : $"{Convert.ToHexString(operand)}",
         };
     }
 
     private static string FormatPushData(byte[] operand)
     {
         var hex = Convert.ToHexString(operand);
-        var asStr = Encoding.UTF8.GetString(operand);
-        if (IsReadableText(asStr))
-            return $"{hex} // {asStr}";
+        if (TryGetReadableText(operand, out var text))
+            return $"{hex} // {text}";
 
         if (TryDecodeEcPoint(operand, out var point))
             return $"{hex} // {point}";
@@ -201,8 +199,28 @@ internal sealed class VMInstruction : IEnumerable<VMInstruction>
     private static string FormatInteger(long value)
         => TryFormatUnixTimestamp(value, out var ts) ? $"{value} // {ts}" : value.ToString(CultureInfo.InvariantCulture);
 
-    private static bool IsReadableText(string value)
-        => value.Length > 0 && value.Any(char.IsAsciiLetter) && value.All(static c => char.IsAscii(c) && !char.IsControl(c));
+    /// <summary>
+    /// Strict UTF-8 whose runes are all printable (not control characters).
+    /// Invalid sequences are rejected; <see cref="Encoding.UTF8"/> replacement is not used.
+    /// </summary>
+    private static bool TryGetReadableText(ReadOnlySpan<byte> utf8, out string text)
+    {
+        text = null!;
+        if (utf8.IsEmpty || !Utf8.IsValid(utf8))
+            return false;
+
+        text = Encoding.UTF8.GetString(utf8);
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (Rune.IsControl(rune))
+            {
+                text = null!;
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     private static bool TryDecodeEcPoint(byte[] operand, out ECPoint point)
     {

--- a/src/Neo.CLI/Tools/VMInstruction.cs
+++ b/src/Neo.CLI/Tools/VMInstruction.cs
@@ -97,9 +97,9 @@ internal sealed class VMInstruction : IEnumerable<VMInstruction>
 
     public override string ToString()
     {
-        var sb = new StringBuilder();
-        sb.AppendFormat("{0:X04} {1,-10}{2}", Position, OpCode, DecodeOperand());
-        return sb.ToString();
+        if (OperandSize == 0)
+            return string.Format("{0:X04} {1}", Position, OpCode);
+        return string.Format("{0:X04} {1,-10}{2}", Position, OpCode, DecodeOperand());
     }
 
     public T AsToken<T>(uint index = 0)

--- a/tests/Neo.CLI.Tests/UT_VMInstruction.cs
+++ b/tests/Neo.CLI.Tests/UT_VMInstruction.cs
@@ -45,6 +45,31 @@ public class UT_VMInstruction
     }
 
     [TestMethod]
+    public void DecimalWidth_GrowsPastFourDigits()
+    {
+        Assert.AreEqual(4, VMInstruction.DecimalWidth(0));
+        Assert.AreEqual(4, VMInstruction.DecimalWidth(9999));
+        Assert.AreEqual(5, VMInstruction.DecimalWidth(10000));
+        Assert.AreEqual(6, VMInstruction.DecimalWidth(100000));
+    }
+
+    [TestMethod]
+    public void HexWidth_GrowsWithScriptLength()
+    {
+        Assert.AreEqual(4, VMInstruction.HexWidth(1));
+        Assert.AreEqual(4, VMInstruction.HexWidth(0x10000));
+        Assert.AreEqual(5, VMInstruction.HexWidth(0x10001));
+    }
+
+    [TestMethod]
+    public void FormatListing_PadsLineNumbersToAtLeastFourDigits()
+    {
+        var listing = VMInstruction.FormatListing(new byte[] { (byte)OpCode.NOP, (byte)OpCode.RET });
+        Assert.StartsWith("L0000:", listing);
+        Assert.Contains("L0001:", listing);
+    }
+
+    [TestMethod]
     public void DecodeOperand_CommentsReadableTextIncludingColon()
     {
         var text = "TWELVEDATA:CNY-USD"u8.ToArray();

--- a/tests/Neo.CLI.Tests/UT_VMInstruction.cs
+++ b/tests/Neo.CLI.Tests/UT_VMInstruction.cs
@@ -1,0 +1,44 @@
+// Copyright (C) 2015-2026 The Neo Project.
+//
+// UT_VMInstruction.cs file belongs to the neo project and is free
+// software distributed under the MIT software license, see the
+// accompanying file LICENSE in the main directory of the
+// repository or http://www.opensource.org/licenses/mit-license.php
+// for more details.
+//
+// Redistribution and use in source and binary forms with or without
+// modifications are permitted.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.CLI;
+using Neo.VM;
+
+namespace Neo.CLI.Tests;
+
+[TestClass]
+public class UT_VMInstruction
+{
+    [TestMethod]
+    public void ToString_OmitsOperandWhenNone()
+    {
+        var instruction = new VMInstruction(new byte[] { (byte)OpCode.NOP });
+        Assert.AreEqual("0000 NOP", instruction.ToString());
+    }
+
+    [TestMethod]
+    public void ToString_IncludesDecodedOperand()
+    {
+        var instruction = new VMInstruction(new byte[] { (byte)OpCode.PUSHINT8, 7 });
+        Assert.AreEqual("0000 PUSHINT8  7", instruction.ToString());
+    }
+
+    [TestMethod]
+    public void Enumerator_WalksFullScript()
+    {
+        var script = new byte[] { (byte)OpCode.NOP, (byte)OpCode.RET };
+        var lines = new VMInstruction(script).Select(i => i.ToString()).ToArray();
+        Assert.HasCount(2, lines);
+        Assert.AreEqual("0000 NOP", lines[0]);
+        Assert.AreEqual("0001 RET", lines[1]);
+    }
+}

--- a/tests/Neo.CLI.Tests/UT_VMInstruction.cs
+++ b/tests/Neo.CLI.Tests/UT_VMInstruction.cs
@@ -65,15 +65,16 @@ public class UT_VMInstruction
     {
         var invalid = new byte[] { 0xC0, 0x80, 0xFF };
         var instruction = new VMInstruction(PushData1(invalid));
-        Assert.AreEqual(Convert.ToHexString(invalid), instruction.DecodeOperand());
+        Assert.AreEqual($"{Convert.ToHexString(invalid)} // blob {invalid.Length} bytes", instruction.DecodeOperand());
     }
 
     [TestMethod]
-    public void DecodeOperand_RejectsControlRunesAsText()
+    public void DecodeOperand_EscapesControlRunesInText()
     {
         var withNl = "ab\ncd"u8.ToArray();
         var instruction = new VMInstruction(PushData1(withNl));
-        Assert.DoesNotContain(" // ", instruction.DecodeOperand());
+        Assert.Contains(" // ab\\ncd", instruction.DecodeOperand());
+        Assert.DoesNotContain("ab\ncd", instruction.DecodeOperand());
     }
 
     [TestMethod]
@@ -118,7 +119,7 @@ public class UT_VMInstruction
         var blob = Convert.FromHexString("71BDDFD76DBDEF67BCF1C71AE77E787B973C69F79C79FF1F");
         Assert.AreEqual(24, blob.Length);
         var instruction = new VMInstruction(PushData1(blob));
-        Assert.AreEqual(Convert.ToHexString(blob), instruction.DecodeOperand());
+        Assert.AreEqual($"{Convert.ToHexString(blob)} // blob 24 bytes", instruction.DecodeOperand());
     }
 
     private static byte[] PushData1(byte[] data)

--- a/tests/Neo.CLI.Tests/UT_VMInstruction.cs
+++ b/tests/Neo.CLI.Tests/UT_VMInstruction.cs
@@ -53,6 +53,30 @@ public class UT_VMInstruction
     }
 
     [TestMethod]
+    public void DecodeOperand_CommentsStrictUtf8PrintableRunes()
+    {
+        var text = "价格 café — ✓"u8.ToArray();
+        var instruction = new VMInstruction(PushData1(text));
+        Assert.Contains(" // 价格 café — ✓", instruction.DecodeOperand());
+    }
+
+    [TestMethod]
+    public void DecodeOperand_RejectsInvalidUtf8AsText()
+    {
+        var invalid = new byte[] { 0xC0, 0x80, 0xFF };
+        var instruction = new VMInstruction(PushData1(invalid));
+        Assert.AreEqual(Convert.ToHexString(invalid), instruction.DecodeOperand());
+    }
+
+    [TestMethod]
+    public void DecodeOperand_RejectsControlRunesAsText()
+    {
+        var withNl = "ab\ncd"u8.ToArray();
+        var instruction = new VMInstruction(PushData1(withNl));
+        Assert.DoesNotContain(" // ", instruction.DecodeOperand());
+    }
+
+    [TestMethod]
     public void DecodeOperand_FormatsUInt160()
     {
         var hash = new UInt160(Convert.FromHexString("ABCC7F51C334D4F958BE8B6C54142AC4493F0103"));

--- a/tests/Neo.CLI.Tests/UT_VMInstruction.cs
+++ b/tests/Neo.CLI.Tests/UT_VMInstruction.cs
@@ -11,6 +11,8 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.CLI;
+using Neo.Cryptography.ECC;
+using Neo.Extensions;
 using Neo.VM;
 
 namespace Neo.CLI.Tests;
@@ -40,5 +42,67 @@ public class UT_VMInstruction
         Assert.HasCount(2, lines);
         Assert.AreEqual("0000 NOP", lines[0]);
         Assert.AreEqual("0001 RET", lines[1]);
+    }
+
+    [TestMethod]
+    public void DecodeOperand_CommentsReadableTextIncludingColon()
+    {
+        var text = "TWELVEDATA:CNY-USD"u8.ToArray();
+        var instruction = new VMInstruction(PushData1(text));
+        Assert.Contains(" // TWELVEDATA:CNY-USD", instruction.DecodeOperand());
+    }
+
+    [TestMethod]
+    public void DecodeOperand_FormatsUInt160()
+    {
+        var hash = new UInt160(Convert.FromHexString("ABCC7F51C334D4F958BE8B6C54142AC4493F0103"));
+        var instruction = new VMInstruction(PushData1(hash.ToArray()));
+        Assert.AreEqual($"{Convert.ToHexString(hash.ToArray())} // {hash}", instruction.DecodeOperand());
+    }
+
+    [TestMethod]
+    public void DecodeOperand_FormatsUInt256()
+    {
+        var hash = new UInt256(new byte[32]);
+        var instruction = new VMInstruction(PushData1(hash.ToArray()));
+        Assert.AreEqual($"{Convert.ToHexString(hash.ToArray())} // {hash}", instruction.DecodeOperand());
+    }
+
+    [TestMethod]
+    public void DecodeOperand_FormatsEcPoint()
+    {
+        var point = ECPoint.Parse("03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c", ECCurve.Secp256r1);
+        var encoded = point.EncodePoint(true);
+        var instruction = new VMInstruction(PushData1(encoded));
+        Assert.AreEqual($"{Convert.ToHexString(encoded)} // {point}", instruction.DecodeOperand());
+    }
+
+    [TestMethod]
+    public void DecodeOperand_CommentsUnixTimestampOnPushInt32()
+    {
+        const int unix = 1_787_908_101;
+        var script = new byte[5];
+        script[0] = (byte)OpCode.PUSHINT32;
+        BitConverter.GetBytes(unix).CopyTo(script, 1);
+        var instruction = new VMInstruction(script);
+        Assert.AreEqual("1787908101 // 2026-08-28T09:08:21Z", instruction.DecodeOperand());
+    }
+
+    [TestMethod]
+    public void DecodeOperand_LeavesNonTypedPushDataAsHex()
+    {
+        var blob = Convert.FromHexString("71BDDFD76DBDEF67BCF1C71AE77E787B973C69F79C79FF1F");
+        Assert.AreEqual(24, blob.Length);
+        var instruction = new VMInstruction(PushData1(blob));
+        Assert.AreEqual(Convert.ToHexString(blob), instruction.DecodeOperand());
+    }
+
+    private static byte[] PushData1(byte[] data)
+    {
+        var script = new byte[2 + data.Length];
+        script[0] = (byte)OpCode.PUSHDATA1;
+        script[1] = (byte)data.Length;
+        Buffer.BlockCopy(data, 0, script, 2, data.Length);
+        return script;
     }
 }


### PR DESCRIPTION
## Summary

`parse` / `ScriptsToOpCode` now uses a single `VMInstruction.ToString()` layout, and `DecodeOperand` annotates operands instead of dumping raw hex.

## Changes

- `ToString()` is `{position} {opcode}` plus operand only when `OperandSize > 0`. Hex position width is at least 4 and grows with script length.
- `ScriptsToOpCode` prefixes that with `L{n}:`. Decimal width is at least 4 (`D04`) and grows with the script size / instruction count (so listings longer than 9999 lines still line up).
- Strict UTF-8 `PUSHDATA*` text (`Utf8.IsValid`) is shown as `hex // text`. Control runes are escaped (`\n`, `\r`, `\t`, `\0`, `\xNN`) so they do not create real newlines in the listing.
- Otherwise, typed comments:
  - 33/65-byte `ECPoint` ΓåÆ `hex // {point}`
  - 20-byte `UInt160` / 32-byte `UInt256` ΓåÆ `hex // {hash}`
  - unix seconds or milliseconds in 2000ΓÇô2100 on `PUSHINT32`/`PUSHINT64` and 4/8-byte `PUSHDATA`
- Remaining payloads: `hex // blob N bytes`.

## Example

`parse` listing of this Base64 `System.Contract.Call(updateFeeds, ΓÇª)` script:

```
L0000:0000 PUSH0
L0001:0001 PUSH0
L0002:0002 PUSH0
L0003:0003 PUSH0
L0004:0004 PUSH0
L0005:0005 PUSH0
L0006:0006 PUSH0
L0007:0007 PUSH0
L0008:0008 PUSH0
L0009:0009 PUSH0
L0010:000A PUSH0
L0011:000B PUSH0
L0012:000C PUSH12
L0013:000D PACK
L0014:000E PUSHDATA1 71BDDFD76DBDEF67BCF1C71AE77E787B973C69F79C79FF1F // blob 24 bytes
L0015:0028 PUSHDATA1 DF4EBBF5E7FDD1FD1BE7DE7979CF3C79A7F879F6F5F7879F // blob 24 bytes
L0016:0042 PUSHDATA1 EFDE7ADDBDDDDF5F7D7396F46BAEDE79AEF6F5B7F4DDAE36 // blob 24 bytes
L0017:005C PUSHDATA1 73B6DDDBAD5EE3DE9DDF969EE79E766FCDDE75AD7CF7AE75 // blob 24 bytes
L0018:0076 PUSHDATA1 D9ED1CEB8DFDD37EB469BF36F7ADB7774EDF77479DE3DF7D // blob 24 bytes
L0019:0090 PUSHDATA1 EB87B4EBC6B67FA7BDF7871E77BF5AD9EE1F7DBEDFEBBF7D // blob 24 bytes
L0020:00AA PUSHDATA1 79E73CEF869D778F1D79B79BD38D1CDF6D9E6F875CDB5775 // blob 24 bytes
L0021:00C4 PUSHDATA1 75B69AEB4F3C777D5B6DAF7AD1EF746B8EF5E5FE3AE37EFB // blob 24 bytes
L0022:00DE PUSHDATA1 DFD6F7E77DF4D38F35EDDD3AE39EDAD5F7F77767F4F766FC // blob 24 bytes
L0023:00F8 PUSHDATA1 739F5DD9ED34E9EE1CDB6D7DDF5F1FEF47F67BADF675FEB8 // blob 24 bytes
L0024:0112 PUSHDATA1 EDEE1BD78D7CEF6EDDF5EEBBF1EE1E6DAE9AF1B77C7F5EBB // blob 24 bytes
L0025:012C PUSHDATA1 D5CE3BE39E76F77F1B6FD738D9BD3B7F67BB71ADDE71C774 // blob 24 bytes
L0026:0146 PUSH12
L0027:0147 PACK
L0028:0148 PUSHINT32 1787908101
L0029:014D PUSHINT32 1787908101
L0030:0152 PUSHINT32 1787908101
L0031:0157 PUSHINT32 1787908101
L0032:015C PUSHINT32 1787908101
L0033:0161 PUSHINT32 1787908101
L0034:0166 PUSHINT32 1787908101
L0035:016B PUSHINT32 1787908101
L0036:0170 PUSHINT32 1787908101
L0037:0175 PUSHINT32 1787908101
L0038:017A PUSHINT32 1787908101
L0039:017F PUSHINT32 1787908101
L0040:0184 PUSH12
L0041:0185 PACK
L0042:0186 PUSHINT32 148800
L0043:018B PUSHINT16 6265
L0044:018E PUSHINT32 771039978
L0045:0193 PUSHINT32 504880000
L0046:0198 PUSHINT32 87170
L0047:019D PUSHINT32 1417300
L0048:01A2 PUSHINT32 999930
L0049:01A7 PUSHINT32 1000020
L0050:01AC PUSHINT32 339700
L0051:01B1 PUSHINT64 2491470000
L0052:01BA PUSHINT64 79426600000
L0053:01C3 PUSHINT32 2162000
L0054:01C8 PUSH12
L0055:01C9 PACK
L0056:01CA PUSHINT32 1787908101
L0057:01CF PUSHINT32 1787908101
L0058:01D4 PUSHINT32 1787908101
L0059:01D9 PUSHINT32 1787908101
L0060:01DE PUSHINT32 1787908101
L0061:01E3 PUSHINT32 1787908101
L0062:01E8 PUSHINT32 1787908101
L0063:01ED PUSHINT32 1787908101
L0064:01F2 PUSHINT32 1787908101
L0065:01F7 PUSHINT32 1787908101
L0066:01FC PUSHINT32 1787908101
L0067:0201 PUSHINT32 1787908101
L0068:0206 PUSH12
L0069:0207 PACK
L0070:0208 PUSHDATA1 5457454C5645444154413A434E592D555344 // TWELVEDATA:CNY-USD
L0071:021C PUSHDATA1 5457454C5645444154413A4A50592D555344 // TWELVEDATA:JPY-USD
L0072:0230 PUSHDATA1 5457454C5645444154413A5350592D555344 // TWELVEDATA:SPY-USD
L0073:0244 PUSHDATA1 5457454C5645444154413A4D5346542D555344 // TWELVEDATA:MSFT-USD
L0074:0259 PUSHDATA1 5457454C5645444154413A444F47452D555344 // TWELVEDATA:DOGE-USD
L0075:026E PUSHDATA1 5457454C5645444154413A5852502D555344 // TWELVEDATA:XRP-USD
L0076:0282 PUSHDATA1 5457454C5645444154413A555344432D555344 // TWELVEDATA:USDC-USD
L0077:0297 PUSHDATA1 5457454C5645444154413A555344542D555344 // TWELVEDATA:USDT-USD
L0078:02AC PUSHDATA1 5457454C5645444154413A5452582D555344 // TWELVEDATA:TRX-USD
L0079:02C0 PUSHDATA1 5457454C5645444154413A4554482D555344 // TWELVEDATA:ETH-USD
L0080:02D4 PUSHDATA1 5457454C5645444154413A4254432D555344 // TWELVEDATA:BTC-USD
L0081:02E8 PUSHDATA1 5457454C5645444154413A4E454F2D555344 // TWELVEDATA:NEO-USD
L0082:02FC PUSH12
L0083:02FD PACK
L0084:02FE PUSH6
L0085:02FF PACK
L0086:0300 PUSH15
L0087:0301 PUSHDATA1 7570646174654665656473 // updateFeeds
L0088:030E PUSHDATA1 ABCC7F51C334D4F958BE8B6C54142AC4493F0103 // 0x03013f49c42a14546c8bbe58f9d434c3517fccab
L0089:0324 SYSCALL   [System.Contract.Call]
```

