### PR TITLE
fix(WalletAPI): invoke unclaimedGas at GetBlockCount height

### DIFF
--- a/plugins/RpcClient/WalletAPI.cs
+++ b/plugins/RpcClient/WalletAPI.cs
@@ -58,7 +58,8 @@ public class WalletAPI
     {
         UInt160 scriptHash = NativeContract.NEO.Hash;
         var blockCount = await rpcClient.GetBlockCountAsync().ConfigureAwait(false);
-        var result = await nep17API.TestInvokeAsync(scriptHash, "unclaimedGas", account, blockCount - 1).ConfigureAwait(false);
+        // Match getunclaimedgas: UnclaimedGas(..., CurrentIndex + 1) == GetBlockCount().
+        var result = await nep17API.TestInvokeAsync(scriptHash, "unclaimedGas", account, blockCount).ConfigureAwait(false);
         BigInteger balance = result.Stack.Single().GetInteger();
         return ((decimal)balance) / (long)NativeContract.GAS.Factor;
     }

--- a/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
@@ -49,7 +49,7 @@ public class UT_WalletAPI
     [TestMethod]
     public async Task TestGetUnclaimedGas()
     {
-        byte[] testScript = NativeContract.NEO.Hash.MakeScript("unclaimedGas", sender, 99);
+        byte[] testScript = NativeContract.NEO.Hash.MakeScript("unclaimedGas", sender, 100);
         UT_TransactionManager.MockInvokeScript(rpcClientMock, testScript, new ContractParameter { Type = ContractParameterType.Integer, Value = new BigInteger(1_10000000) });
 
         var balance = await walletAPI.GetUnclaimedGasAsync(address1);


### PR DESCRIPTION
`getunclaimedgas` uses `NativeContract.NEO.UnclaimedGas(..., CurrentIndex + 1)`. `WalletAPI.GetUnclaimedGasAsync` invoked `unclaimedGas` with `GetBlockCount() - 1` (`CurrentIndex`), so the client helper under-counted by one block versus the RPC method.

Independent of other PRs. RpcClient helper only; not consensus-critical.