### PR TITLE
fix(RpcClient): throw on non-success HTTP before parsing JSON

### DIFF
--- a/plugins/RpcClient/RpcClient.cs
+++ b/plugins/RpcClient/RpcClient.cs
@@ -115,6 +115,7 @@ public class RpcClient : IDisposable
 
         using var requestMsg = AsHttpRequest(request);
         using var responseMsg = _httpClient.Send(requestMsg);
+        responseMsg.EnsureSuccessStatusCode();
         using var contentStream = responseMsg.Content.ReadAsStream();
         using var contentReader = new StreamReader(contentStream);
         return AsRpcResponse(contentReader.ReadToEnd(), throwOnError);
@@ -126,7 +127,8 @@ public class RpcClient : IDisposable
 
         using var requestMsg = AsHttpRequest(request);
         using var responseMsg = await _httpClient.SendAsync(requestMsg).ConfigureAwait(false);
-        var content = await responseMsg.Content.ReadAsStringAsync();
+        responseMsg.EnsureSuccessStatusCode();
+        var content = await responseMsg.Content.ReadAsStringAsync().ConfigureAwait(false);
         return AsRpcResponse(content, throwOnError);
     }
 

--- a/tests/Neo.Network.RPC.Tests/UT_RpcClient.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_RpcClient.cs
@@ -616,4 +616,24 @@ public class UT_RpcClient
     }
 
     #endregion Plugins
+
+    [TestMethod]
+    public async Task TestHttpErrorStatus_ThrowsBeforeJsonParse()
+    {
+        handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handlerMock.Protected()
+           .Setup<Task<HttpResponseMessage>>(
+              "SendAsync",
+              ItExpr.IsAny<HttpRequestMessage>(),
+              ItExpr.IsAny<CancellationToken>())
+           .ReturnsAsync(new HttpResponseMessage()
+           {
+               StatusCode = HttpStatusCode.InternalServerError,
+               Content = new StringContent("<html>gateway error</html>"),
+           })
+           .Verifiable();
+        rpc = new RpcClient(new HttpClient(handlerMock.Object), new Uri("http://seed1.neo.org:10331"), null);
+
+        await Assert.ThrowsExactlyAsync<HttpRequestException>(() => rpc.GetBlockCountAsync());
+    }
 }


### PR DESCRIPTION
`Send`/`SendAsync` parsed the body even when the HTTP status was 4xx/5xx. Proxy HTML and gateway errors became JSON parse failures instead of `HttpRequestException`.

JSON-RPC errors still arrive as HTTP 200 with an error object and are unchanged.

Independent of other PRs. RpcClient only; not consensus-critical.