### PR TITLE
fix(WalletAPI): sleep between WaitTransaction retries on RPC errors

### DIFF
--- a/plugins/RpcClient/WalletAPI.cs
+++ b/plugins/RpcClient/WalletAPI.cs
@@ -199,6 +199,7 @@ public class WalletAPI
     {
         DateTime deadline = DateTime.UtcNow.AddSeconds(timeout);
         RpcTransaction rpcTx = null;
+        var pollDelay = Math.Max(100, (int)rpcClient.protocolSettings.MillisecondsPerBlock / 2);
         while (rpcTx == null || rpcTx.Confirmations == null)
         {
             if (deadline < DateTime.UtcNow)
@@ -211,10 +212,15 @@ public class WalletAPI
                 rpcTx = await rpcClient.GetRawTransactionAsync(transaction.Hash.ToString()).ConfigureAwait(false);
                 if (rpcTx == null || rpcTx.Confirmations == null)
                 {
-                    await Task.Delay((int)rpcClient.protocolSettings.MillisecondsPerBlock / 2);
+                    await Task.Delay(pollDelay).ConfigureAwait(false);
                 }
             }
-            catch (Exception) { }
+            catch (Exception)
+            {
+                // Unknown tx and transient RPC errors retry until timeout;
+                // sleep so a persistent failure cannot busy-loop the CPU.
+                await Task.Delay(pollDelay).ConfigureAwait(false);
+            }
         }
         return rpcTx;
     }

--- a/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_WalletAPI.cs
@@ -172,4 +172,30 @@ public class UT_WalletAPI
         Assert.AreEqual(VMState.HALT, tx.VMState);
         Assert.AreEqual(UInt256.Zero, tx.BlockHash);
     }
+
+    [TestMethod]
+    public async Task TestWaitTransaction_RetriesAfterRpcError()
+    {
+        Transaction transaction = TestUtils.GetTransaction();
+        var callCount = 0;
+        rpcClientMock.Setup(p => p.RpcSendAsync("getrawtransaction", It.Is<JToken[]>(j => j[0].AsString() == transaction.Hash.ToString())))
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    return Task.FromException<JToken>(new RpcException(-100, "Unknown transaction"));
+                return Task.FromResult<JToken>(new RpcTransaction
+                {
+                    Transaction = transaction,
+                    VMState = VMState.HALT,
+                    BlockHash = UInt256.Zero,
+                    BlockTime = 100,
+                    Confirmations = 1
+                }.ToJson(client.protocolSettings));
+            });
+
+        var tx = await walletAPI.WaitTransactionAsync(transaction, timeout: 20);
+        Assert.AreEqual(2, callCount);
+        Assert.AreEqual(VMState.HALT, tx.VMState);
+    }
 }


### PR DESCRIPTION
`WaitTransactionAsync` swallowed `GetRawTransaction` failures with an empty catch and no delay. A missing transaction or persistent RPC error busy-looped the CPU until timeout.

Sleep on both unknown-tx and exception paths, with a 100ms floor, and retry until the tx has confirmations.

Independent of other PRs. RpcClient helper only; not consensus-critical.