### PR TITLE
fix(RpcClient): fail NEP-17 and Policy helpers when invoke FAULTs

### DIFF
--- a/plugins/RpcClient/ContractClient.cs
+++ b/plugins/RpcClient/ContractClient.cs
@@ -16,6 +16,7 @@ using Neo.SmartContract;
 using Neo.SmartContract.Manifest;
 using Neo.SmartContract.Native;
 using Neo.VM;
+using Neo.VM.Types;
 using Neo.Wallets;
 
 namespace Neo.Network.RPC;
@@ -47,6 +48,15 @@ public class ContractClient
     {
         byte[] script = scriptHash.MakeScript(operation, args);
         return rpcClient.InvokeScriptAsync(script);
+    }
+
+    protected static StackItem RequireHaltResult(RpcInvokeResult result, int minStackLength = 1)
+    {
+        if (result.State != VMState.HALT)
+            throw new InvalidOperationException($"Contract invoke faulted ({result.State}): {result.Exception}");
+        if (result.Stack is null || result.Stack.Length < minStackLength)
+            throw new InvalidOperationException("Contract invoke returned no result.");
+        return result.Stack[0];
     }
 
     /// <summary>

--- a/plugins/RpcClient/Nep17API.cs
+++ b/plugins/RpcClient/Nep17API.cs
@@ -40,8 +40,7 @@ public class Nep17API : ContractClient
     public async Task<BigInteger> BalanceOfAsync(UInt160 scriptHash, UInt160 account)
     {
         var result = await TestInvokeAsync(scriptHash, "balanceOf", account).ConfigureAwait(false);
-        BigInteger balance = result.Stack.Single().GetInteger();
-        return balance;
+        return RequireHaltResult(result).GetInteger();
     }
 
     /// <summary>
@@ -52,7 +51,7 @@ public class Nep17API : ContractClient
     public async Task<string> SymbolAsync(UInt160 scriptHash)
     {
         var result = await TestInvokeAsync(scriptHash, "symbol").ConfigureAwait(false);
-        return result.Stack.Single().GetString();
+        return RequireHaltResult(result).GetString();
     }
 
     /// <summary>
@@ -63,7 +62,7 @@ public class Nep17API : ContractClient
     public async Task<byte> DecimalsAsync(UInt160 scriptHash)
     {
         var result = await TestInvokeAsync(scriptHash, "decimals").ConfigureAwait(false);
-        return (byte)result.Stack.Single().GetInteger();
+        return (byte)RequireHaltResult(result).GetInteger();
     }
 
     /// <summary>
@@ -74,7 +73,7 @@ public class Nep17API : ContractClient
     public async Task<BigInteger> TotalSupplyAsync(UInt160 scriptHash)
     {
         var result = await TestInvokeAsync(scriptHash, "totalSupply").ConfigureAwait(false);
-        return result.Stack.Single().GetInteger();
+        return RequireHaltResult(result).GetInteger();
     }
 
     /// <summary>
@@ -91,6 +90,7 @@ public class Nep17API : ContractClient
             .. scriptHash.MakeScript("totalSupply")];
         var name = contractState.Manifest.Name;
         var result = await rpcClient.InvokeScriptAsync(script).ConfigureAwait(false);
+        RequireHaltResult(result, 3);
         var stack = result.Stack;
 
         return new RpcNep17TokenInfo
@@ -111,6 +111,7 @@ public class Nep17API : ContractClient
             .. contractState.Hash.MakeScript("totalSupply")];
         var name = contractState.Manifest.Name;
         var result = await rpcClient.InvokeScriptAsync(script).ConfigureAwait(false);
+        RequireHaltResult(result, 3);
         var stack = result.Stack;
 
         return new RpcNep17TokenInfo

--- a/plugins/RpcClient/PolicyAPI.cs
+++ b/plugins/RpcClient/PolicyAPI.cs
@@ -33,7 +33,7 @@ public class PolicyAPI : ContractClient
     public async Task<uint> GetExecFeeFactorAsync()
     {
         var result = await TestInvokeAsync(scriptHash, "getExecFeeFactor").ConfigureAwait(false);
-        return (uint)result.Stack.Single().GetInteger();
+        return (uint)RequireHaltResult(result).GetInteger();
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public class PolicyAPI : ContractClient
     public async Task<uint> GetStoragePriceAsync()
     {
         var result = await TestInvokeAsync(scriptHash, "getStoragePrice").ConfigureAwait(false);
-        return (uint)result.Stack.Single().GetInteger();
+        return (uint)RequireHaltResult(result).GetInteger();
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public class PolicyAPI : ContractClient
     public async Task<long> GetFeePerByteAsync()
     {
         var result = await TestInvokeAsync(scriptHash, "getFeePerByte").ConfigureAwait(false);
-        return (long)result.Stack.Single().GetInteger();
+        return (long)RequireHaltResult(result).GetInteger();
     }
 
     /// <summary>
@@ -63,6 +63,6 @@ public class PolicyAPI : ContractClient
     public async Task<bool> IsBlockedAsync(UInt160 account)
     {
         var result = await TestInvokeAsync(scriptHash, "isBlocked", new object[] { account }).ConfigureAwait(false);
-        return result.Stack.Single().GetBoolean();
+        return RequireHaltResult(result).GetBoolean();
     }
 }

--- a/tests/Neo.Network.RPC.Tests/UT_Nep17API.cs
+++ b/tests/Neo.Network.RPC.Tests/UT_Nep17API.cs
@@ -12,6 +12,7 @@
 using Moq;
 using Neo.Extensions;
 using Neo.Json;
+using Neo.Network.RPC.Models;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
 using Neo.VM;
@@ -160,5 +161,27 @@ public class UT_Nep17API
 
         result = await nep17API.CreateTransferTxAsync(NativeContract.GAS.Hash, keyPair1, UInt160.Zero, new BigInteger(1_00000000), string.Empty, true);
         Assert.IsNotNull(result);
+    }
+
+    [TestMethod]
+    public async Task TestBalanceOf_Fault_Throws()
+    {
+        byte[] testScript = NativeContract.GAS.Hash.MakeScript("balanceOf", UInt160.Zero);
+        var fault = new RpcInvokeResult
+        {
+            Stack = [],
+            GasConsumed = 100,
+            Script = Convert.ToBase64String(testScript),
+            State = VMState.FAULT,
+            Exception = "insufficient gas"
+        };
+        rpcClientMock.Setup(p => p.RpcSendAsync("invokescript", It.Is<JToken[]>(j =>
+            Convert.FromBase64String(j[0].AsString()).SequenceEqual(testScript))))
+            .ReturnsAsync(fault.ToJson())
+            .Verifiable();
+
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            nep17API.BalanceOfAsync(NativeContract.GAS.Hash, UInt160.Zero));
+        StringAssert.Contains(ex.Message, "FAULT");
     }
 }


### PR DESCRIPTION
`BalanceOf`/`symbol`/`decimals` and Policy getters called `Stack.Single()` even when `invokescript` returned FAULT or an empty stack. Callers got `NullReferenceException` or a generic empty-sequence error instead of the VM exception.

Require `VMState.HALT` and a non-empty stack before reading results.

Independent of other PRs. RpcClient helper only; not consensus-critical.