### PR TITLE
fix(RpcServer): return UnknownAccount from dumpprivkey for watch-only keys

### DIFF
--- a/plugins/RpcServer/RpcServer.Wallet.cs
+++ b/plugins/RpcServer/RpcServer.Wallet.cs
@@ -78,7 +78,8 @@ partial class RpcServer
     {
         return CheckWallet().GetAccount(address.ScriptHash)
             .NotNull_Or(RpcError.UnknownAccount.WithData($"{address.ScriptHash}"))
-            .GetKey()!
+            .GetKey()
+            .NotNull_Or(RpcError.UnknownAccount.WithData($"{address.ScriptHash}"))
             .Export();
     }
 

--- a/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
+++ b/tests/Neo.Plugins.RpcServer.Tests/UT_RpcServer.Wallet.cs
@@ -131,6 +131,18 @@ partial class UT_RpcServer
     }
 
     [TestMethod]
+    public void TestDumpPrivKey_WatchOnly_ThrowsUnknownAccount()
+    {
+        TestUtilOpenWallet();
+        var watchOnly = UInt160.Parse("0x0000000000000000000000000000000000000001");
+        _rpcServer.wallet.CreateAccount(watchOnly);
+        var address = watchOnly.ToAddress(ProtocolSettings.Default.AddressVersion);
+        var ex = Assert.ThrowsExactly<RpcException>(() => _rpcServer.DumpPrivKey(new JString(address).AsParameter<Address>()));
+        Assert.AreEqual(RpcError.UnknownAccount.Code, ex.HResult);
+        TestUtilCloseWallet();
+    }
+
+    [TestMethod]
     public void TestDumpPrivKey_InvalidAddressFormat()
     {
         TestUtilOpenWallet();


### PR DESCRIPTION
`GetKey()` is null for watch-only accounts. The null-forgiving `Export()` threw `NullReferenceException` instead of `-305 Unknown account`.

Independent of other PRs.