### PR TITLE
fix(ApplicationLogs): reject invalid getapplicationlog triggerType

### DIFF
--- a/plugins/ApplicationLogs/LogReader.cs
+++ b/plugins/ApplicationLogs/LogReader.cs
@@ -118,13 +118,18 @@ public class LogReader : Plugin
             if (raw == null) throw new RpcException(RpcError.InvalidParams.WithData("Unknown transaction/blockhash"));
         }
 
-        if (!string.IsNullOrEmpty(triggerType) && Enum.TryParse(triggerType, true, out TriggerType _))
+        if (!string.IsNullOrEmpty(triggerType))
         {
+            if (!Enum.TryParse(triggerType, true, out TriggerType trigger)
+                || !Enum.GetNames<TriggerType>().Any(n => n.Equals(triggerType, StringComparison.OrdinalIgnoreCase)))
+                throw new RpcException(RpcError.InvalidParams.WithData($"Invalid trigger type: {triggerType}"));
+
             if (raw["executions"] is JArray executions)
             {
+                var triggerName = trigger.ToString();
                 for (var i = 0; i < executions.Count;)
                 {
-                    if (executions[i]!["trigger"]?.AsString().Equals(triggerType, StringComparison.OrdinalIgnoreCase) == false)
+                    if (executions[i]!["trigger"]?.AsString().Equals(triggerName, StringComparison.OrdinalIgnoreCase) == false)
                         executions.RemoveAt(i);
                     else
                         i++;

--- a/tests/Neo.Plugins.ApplicationLogs.Tests/UT_LogReader.cs
+++ b/tests/Neo.Plugins.ApplicationLogs.Tests/UT_LogReader.cs
@@ -18,6 +18,7 @@ using Neo.Persistence;
 using Neo.Persistence.Providers;
 using Neo.Plugins.ApplicationLogs;
 using Neo.Plugins.ApplicationLogs.Store.Models;
+using Neo.Plugins.RpcServer;
 using Neo.SmartContract;
 using Neo.SmartContract.Native;
 using Neo.VM;
@@ -157,8 +158,11 @@ public class UT_LogReader
         Assert.HasCount(1, executions);
         Assert.AreEqual("PostPersist", executions[0]["trigger"]);
 
-        // "true" is invalid but still works
-        JObject transactionJson = (JObject)s_neoSystemFixture.logReader.GetApplicationLog(s_neoSystemFixture.txs[0].Hash.ToString(), "true");
+        var invalidTrigger = Assert.ThrowsExactly<RpcException>(() =>
+            s_neoSystemFixture.logReader.GetApplicationLog(block.Hash, "true"));
+        Assert.AreEqual(RpcError.InvalidParams.Code, invalidTrigger.HResult);
+
+        JObject transactionJson = (JObject)s_neoSystemFixture.logReader.GetApplicationLog(s_neoSystemFixture.txs[0].Hash);
         executions = (JArray)transactionJson["executions"];
         Assert.HasCount(1, executions);
         Assert.AreEqual(nameof(VMState.HALT), executions[0]["vmstate"]);


### PR DESCRIPTION
Docs say an invalid trigger throws. `Enum.TryParse` failing skipped the filter, so callers got unfiltered executions. Numeric strings such as `16` also parsed as undefined enum values.

Require a named `TriggerType` or return `InvalidParams`.

Independent of other PRs.