### PR TITLE
fix(Oracle): skip watch-only accounts when refreshing response signatures

### DIFF
--- a/plugins/OracleService/OracleService.cs
+++ b/plugins/OracleService/OracleService.cs
@@ -235,8 +235,13 @@ public sealed class OracleService : Plugin
                 if (span > TimeSpan.FromMilliseconds(RefreshIntervalMilliSeconds))
                 {
                     foreach (var account in wallet.GetAccounts())
-                        if (task.BackupSigns.TryGetValue(account.GetKey().PublicKey, out byte[] sign))
-                            tasks.Add(SendResponseSignatureAsync(id, sign, account.GetKey()));
+                    {
+                        if (!account.HasKey || account.Lock) continue;
+                        var key = account.GetKey();
+                        if (key is null) continue;
+                        if (task.BackupSigns.TryGetValue(key.PublicKey, out byte[] sign))
+                            tasks.Add(SendResponseSignatureAsync(id, sign, key));
+                    }
                 }
             }
 

--- a/plugins/OracleService/OracleService.cs
+++ b/plugins/OracleService/OracleService.cs
@@ -234,14 +234,8 @@ public sealed class OracleService : Plugin
 
                 if (span > TimeSpan.FromMilliseconds(RefreshIntervalMilliSeconds))
                 {
-                    foreach (var account in wallet.GetAccounts())
-                    {
-                        if (!account.HasKey || account.Lock) continue;
-                        var key = account.GetKey();
-                        if (key is null) continue;
-                        if (task.BackupSigns.TryGetValue(key.PublicKey, out byte[] sign))
-                            tasks.Add(SendResponseSignatureAsync(id, sign, key));
-                    }
+                    foreach (var (key, sign) in CollectRefreshSignatures(wallet, task.BackupSigns))
+                        tasks.Add(SendResponseSignatureAsync(id, sign, key));
                 }
             }
 
@@ -641,6 +635,20 @@ public sealed class OracleService : Plugin
     private static bool CheckOracleAccount(ISigner signer, ECPoint[] oracles)
     {
         return signer is not null && oracles.Any(p => signer.ContainsSignable(p));
+    }
+
+    internal static List<(KeyPair Key, byte[] Sign)> CollectRefreshSignatures(Wallet wallet, IReadOnlyDictionary<ECPoint, byte[]> backupSigns)
+    {
+        var matches = new List<(KeyPair Key, byte[] Sign)>();
+        foreach (var account in wallet.GetAccounts())
+        {
+            if (!account.HasKey || account.Lock) continue;
+            var key = account.GetKey();
+            if (key is null) continue;
+            if (backupSigns.TryGetValue(key.PublicKey, out byte[] sign))
+                matches.Add((key, sign));
+        }
+        return matches;
     }
 
     class OracleTask

--- a/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
+++ b/tests/Neo.Plugins.OracleService.Tests/UT_OracleService.cs
@@ -13,7 +13,9 @@ using Neo.Cryptography.ECC;
 using Neo.Extensions;
 using Neo.Network.P2P.Payloads;
 using Neo.Plugins.OracleService.Protocols;
+using Neo.SmartContract;
 using Neo.SmartContract.Native;
+using Neo.Wallets;
 using System.Collections.Concurrent;
 using static Neo.Plugins.OracleService.Tests.TestBlockchain;
 
@@ -46,6 +48,63 @@ public class UT_OracleService
             OracleService.Filter(json, "$.Manufacturers[1].Products[0].Name").ToStrictUtf8String());
         Assert.AreEqual(@"[{""Name"":""Elbow Grease"",""Price"":99.95}]",
             OracleService.Filter(json, "$.Manufacturers[1].Products[0]").ToStrictUtf8String());
+    }
+
+    [TestMethod]
+    public void CollectRefreshSignatures_WatchOnlyDoesNotThrow()
+    {
+        var wallet = TestUtils.GenerateTestWallet("pwd");
+        wallet.CreateAccount(UInt160.Zero);
+        var signs = new Dictionary<ECPoint, byte[]>();
+
+        var matches = OracleService.CollectRefreshSignatures(wallet, signs);
+        Assert.IsEmpty(matches);
+    }
+
+    [TestMethod]
+    public void CollectRefreshSignatures_WatchOnlyThenKeyedStillMatches()
+    {
+        var wallet = TestUtils.GenerateTestWallet("pwd");
+        wallet.CreateAccount(UInt160.Parse("0x0000000000000000000000000000000000000001"));
+        var keyed = wallet.CreateAccount();
+        Assert.IsNotNull(keyed);
+        var key = keyed.GetKey();
+        Assert.IsNotNull(key);
+
+        byte[] signature = [1, 2, 3];
+        var signs = new Dictionary<ECPoint, byte[]> { [key.PublicKey] = signature };
+
+        var matches = OracleService.CollectRefreshSignatures(wallet, signs);
+        Assert.HasCount(1, matches);
+        Assert.AreEqual(key.PublicKey, matches[0].Key.PublicKey);
+        CollectionAssert.AreEqual(signature, matches[0].Sign);
+    }
+
+    [TestMethod]
+    public void CollectRefreshSignatures_SkipsLockedAccount()
+    {
+        var wallet = TestUtils.GenerateTestWallet("pwd");
+        var account = wallet.CreateAccount();
+        Assert.IsNotNull(account);
+        var key = account.GetKey();
+        Assert.IsNotNull(key);
+        account.Lock = true;
+
+        var signs = new Dictionary<ECPoint, byte[]> { [key.PublicKey] = new byte[] { 9 } };
+        var matches = OracleService.CollectRefreshSignatures(wallet, signs);
+        Assert.IsEmpty(matches);
+    }
+
+    [TestMethod]
+    public void CollectRefreshSignatures_IgnoresUnrelatedKeys()
+    {
+        var wallet = TestUtils.GenerateTestWallet("pwd");
+        wallet.CreateAccount();
+        var other = TestUtils.GenerateTestWallet("pwd").CreateAccount()!.GetKey()!;
+        var signs = new Dictionary<ECPoint, byte[]> { [other.PublicKey] = new byte[] { 4 } };
+
+        var matches = OracleService.CollectRefreshSignatures(wallet, signs);
+        Assert.IsEmpty(matches);
     }
 
     [TestMethod]


### PR DESCRIPTION
The refresh timer called `GetKey().PublicKey` with no null check. A watch-only account NRE'd and the outer catch skipped the rest of that tick.

Match `ProcessRequestAsync`: skip `!HasKey`, locked, and null keys.

Independent of other PRs.